### PR TITLE
Handle sequences with multiple services correctly.

### DIFF
--- a/src/modules/uv-shared-module/baseProvider.ts
+++ b/src/modules/uv-shared-module/baseProvider.ts
@@ -157,11 +157,19 @@ export class BaseProvider implements IProvider{
     }
 
     getManifestation(type: string): string {
-        var service = this.sequence.service;
+        var services = this.sequence.service;
+        if (services) {
+            if (!$.isArray(services)) {
+                services = [services];
+            }
 
-        if (service && service["profile"] === "http://iiif.io/api/otherManifestations.json"){
-            if (service.format.endsWith("pdf")){
-                return service["@id"];
+            for (var i = 0; i < services.length; i++) {
+                var service = services[i];
+                if (service && service["profile"] === "http://iiif.io/api/otherManifestations.json"){
+                    if (service.format.endsWith("pdf")){
+                        return service["@id"];
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Right now, the logic for displaying a PDF download link only works if exactly one service is configured. However, it seems realistic that a manifest might define multiple services for a single sequence (i.e. "PDF Download," "MS Word Download," etc.). This PR makes the code a bit more flexible so it can handle both single- and multi-valued service entries.

Note that I'm not sure if this is up to spec, but it seems like a reasonable use case.

Assuming that multiple services are legal in the spec (and I think they should be), another consideration is the possibility of multiple PDF services for the same sequence (e.g. differently formatted renderings of the same content); it seems that it might be reasonable to account for this, and also to make use of the label property found in the service definition. This PR does not account for either of those potential features.

I'm completely new to this project, and it appears to me that this particular feature is a work in progress (given that there's an unused type parameter and a hard-coded "pdf" string in the method that I modified), so apologies if I'm jumping on this prematurely -- but I'm interested in making this functionality better and would be interested in talking to anyone who is actively working on the implementation.

Thanks!