### PR TITLE
Allow whole-document download options even in paging mode.

### DIFF
--- a/src/extensions/uv-seadragon-extension/downloadDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/downloadDialogue.ts
@@ -29,6 +29,11 @@ export class DownloadDialogue extends dialogue.Dialogue {
 
     }
 
+    close(): void {
+        this.isOpened = false;
+        super.close();
+    }
+
     create(): void {
 
         this.setConfig('downloadDialogue');
@@ -152,18 +157,26 @@ export class DownloadDialogue extends dialogue.Dialogue {
         // enable download based on license code.
         if (this.isDownloadOptionAvailable("currentViewAsJpg")) {
             this.$currentViewAsJpgButton.show();
+        } else {
+            this.$currentViewAsJpgButton.hide();
         }
 
         if (this.isDownloadOptionAvailable("wholeImageHighResAsJpg")) {
             this.$wholeImageHighResAsJpgButton.show();
+        } else {
+            this.$wholeImageHighResAsJpgButton.hide();
         }
 
         if (this.isDownloadOptionAvailable("wholeImageLowResAsJpg")) {
             this.$wholeImageLowResAsJpgButton.show();
+        } else {
+            this.$wholeImageLowResAsJpgButton.hide();
         }
 
         if (this.isDownloadOptionAvailable("entireDocumentAsPdf")) {
             this.$entireDocumentAsPdfButton.show();
+        } else {
+            this.$entireDocumentAsPdfButton.hide();
         }
 
         //if (this.isDownloadOptionAvailable("entireFileAsOriginal")) {
@@ -213,7 +226,11 @@ export class DownloadDialogue extends dialogue.Dialogue {
 
             return false;
         }
-        return true;
+
+        // If we got this far, options only apply in 1-up mode; if we're
+        // showing multiple pages, we have to suppress download options.
+        var settings: ISettings = this.provider.getSettings();
+        return !settings.pagingEnabled;
     }
 
     resize(): void {

--- a/src/modules/uv-shared-module/footerPanel.ts
+++ b/src/modules/uv-shared-module/footerPanel.ts
@@ -98,7 +98,7 @@ export class FooterPanel extends baseView.BaseView {
         var configEnabled = utils.Utils.getBool(this.options.downloadEnabled, true);
         var settings: ISettings = this.provider.getSettings();
 
-        if (configEnabled && !settings.pagingEnabled){
+        if (configEnabled && (!settings.pagingEnabled || this.provider.getManifestation("pdf"))){
             this.$downloadButton.show();
         } else {
             this.$downloadButton.hide();


### PR DESCRIPTION
Now that we have the option to download an entire document, we shouldn't have to disable the download button when we're in paging mode. Instead, we simply want to hide the single-page-specific options. This PR should take care of that -- if a PDF is available, the download button is always visible, but the options within the dialog box change based on the paging mode.

It might be nice to add some higher-level abstraction to make this easier to maintain, but hopefully this is a good start at least!