### PR TITLE
Fixed bug: scrolling past edge of list would break viewPage().

### DIFF
--- a/src/extensions/uv-seadragon-extension/extension.ts
+++ b/src/extensions/uv-seadragon-extension/extension.ts
@@ -345,10 +345,10 @@ export class Extension extends baseExtension.BaseExtension {
             return;
         }
 
-        this.isLoading = true;
-
         // if it's a valid canvas index.
         if (canvasIndex == -1) return;
+
+        this.isLoading = true;
 
         if (this.provider.isPagingSettingEnabled() && !isReload){
             var indices = this.provider.getPagedIndices(canvasIndex);


### PR DESCRIPTION
If you tried to go past the beginning or end of the page list (either by holding down pageUp/pageDown or by clicking on the disabled prev/next controls) the entire interface would stop responding. This was caused by a "this.loading" flag being set to true PRIOR to the out-of-range check. Adjusting the order of the lines fixed the problem.