### PR TITLE
More granular control over CORS/JSONP behavior.

### DIFF
--- a/src/bootstrapper.ts
+++ b/src/bootstrapper.ts
@@ -29,7 +29,8 @@ class BootStrapper{
 
         p.manifestUri = util.getQuerystringParameter('manifestUri');
         p.config = util.getQuerystringParameter('config');
-        p.jsonp = util.getBool(util.getQuerystringParameter('jsonp'), false);
+        var jsonpParam = util.getQuerystringParameter('jsonp');
+        p.jsonp = jsonpParam === null ? null : !(jsonpParam === "false" || jsonpParam === "0");
         p.isHomeDomain = util.getQuerystringParameter('isHomeDomain') === "true";
         p.isReload = util.getQuerystringParameter('isReload') === "true";
         p.setLocale(util.getQuerystringParameter('locale'));

--- a/src/modules/uv-shared-module/baseProvider.ts
+++ b/src/modules/uv-shared-module/baseProvider.ts
@@ -116,7 +116,8 @@ export class BaseProvider implements IProvider{
     }
 
     corsEnabled(): boolean {
-        return Modernizr.cors && !this.jsonp
+        // No jsonp setting? Then use autodetection. Otherwise, use explicit setting.
+        return (null === this.jsonp) ? Modernizr.cors : !this.jsonp;
     }
 
     reloadManifest(callback: any): void {


### PR DESCRIPTION
As discussed in #54, this allows the choice between "force CORS," "force JSONP" and "autodetect based on capabilities."

Note that there seems to be a problem with the way utils.getBool() was being used to initialize the jsonp value in the bootstrapper -- even though the property is typed as boolean, it was actually getting assigned a string of "true" or "false". This inconsistency caused problems down the line since all values would evaluate to boolean true. I tried to fix getBool to convert strings like "true" and "false" to equivalent boolean values, but this caused the entire application to break -- I think there may be some code making undesirable assumptions somewhere. Rather than delve deeper into that problem, I opted to simply work around getBool entirely for the purposes of this PR. Somebody with a deeper knowledge of the code should probably look into this, though!