### PR TITLE
Display download warning when in two-up page mode.

### DIFF
--- a/src/extensions/uv-seadragon-extension/downloadDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/downloadDialogue.ts
@@ -12,6 +12,7 @@ export class DownloadDialogue extends dialogue.Dialogue {
 
     $title: JQuery;
     $noneAvailable: JQuery;
+    $pagingNote: JQuery;
     $downloadOptions: JQuery;
     $currentViewAsJpgButton: JQuery;
     $wholeImageHighResAsJpgButton: JQuery;
@@ -50,6 +51,9 @@ export class DownloadDialogue extends dialogue.Dialogue {
 
         this.$noneAvailable = $('<div class="noneAvailable">' + this.content.noneAvailable + '</div>');
         this.$content.append(this.$noneAvailable);
+
+        this.$pagingNote = $('<div class="pagingNote">' + this.content.pagingNote + '</div>');
+        this.$content.append(this.$pagingNote);
 
         this.$downloadOptions = $('<ol class="options"></ol>');
         this.$content.append(this.$downloadOptions);
@@ -172,6 +176,13 @@ export class DownloadDialogue extends dialogue.Dialogue {
             this.$downloadOptions.find('input:visible:first').prop("checked", true);
             this.$noneAvailable.hide();
             this.$downloadButton.show();
+        }
+
+        var settings: ISettings = this.provider.getSettings();
+        if (settings.pagingEnabled) {
+            this.$pagingNote.show();
+        } else {
+            this.$pagingNote.hide();
         }
 
         this.resize();

--- a/src/extensions/uv-seadragon-extension/l10n/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/en-GB.json
@@ -22,6 +22,7 @@
                 "entireDocumentAsPdf": "Entire document (pdf)",
                 "entireFileAsOriginal": "Entire file ({0})",
                 "noneAvailable": "No download options are available.",
+                "pagingNote": "Please switch to single page mode for additional options.",
                 "preview": "Preview",
                 "title": "Download",
                 "wholeImageHighResAsJpg": "Whole image high res (jpg)",

--- a/src/extensions/uv-seadragon-extension/l10n/xx-XX.json
+++ b/src/extensions/uv-seadragon-extension/l10n/xx-XX.json
@@ -19,6 +19,7 @@
                 "entireDocumentAsPdf": "Entire document (pdf) (xx-XX)",
                 "entireFileAsOriginal": "Entire file ({0}) (xx-XX)",
                 "noneAvailable": "No download options are available. (xx-XX)",
+                "pagingNote": "Please switch to single page mode for additional options. (xx-XX)",
                 "preview": "Preview (xx-XX)",
                 "title": "Download (xx-XX)",
                 "wholeImageHighResAsJpg": "Whole image high res (jpg) (xx-XX)",


### PR DESCRIPTION
It's rather confusing that the page mode determines which download options are available (though I understand the reasoning behind it). This PR adds messaging to alert users' attention to this fact.

This is intended as a proof of concept and is not really fit to be merged as-is; I was unable to provide a Welsh translation, and I'm sure better wording/styling/positioning could be determined for the actual message. Ideally it would be nice if we could really focus the user's attention on which button they need to press to fix the problem (or even offer a functioning option within the download box) since this is not at all obvious in my opinion.

Anyway, I hope this is a foundation that can be built upon. I'm happy to do more work on this if you have suggestions on a forward course.