### PR TITLE
Allow download of original images from manifest.

### DIFF
--- a/src/extensions/uv-seadragon-extension/DownloadOption.ts
+++ b/src/extensions/uv-seadragon-extension/DownloadOption.ts
@@ -5,6 +5,7 @@ class DownloadOption {
     static entireDocumentAsPDF = new DownloadOption("entireDocumentAsPDF");
     static wholeImageHighResAsJpg = new DownloadOption("wholeImageHighResAsJpg");
     static wholeImageLowResAsJpg = new DownloadOption("wholeImageLowResAsJpg");
+    static wholeImageOriginal = new DownloadOption("wholeImageOriginal");
 
     constructor(public value: string) {
     }

--- a/src/extensions/uv-seadragon-extension/downloadDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/downloadDialogue.ts
@@ -19,6 +19,7 @@ export class DownloadDialogue extends dialogue.Dialogue {
     $currentViewAsJpgButton: JQuery;
     $wholeImageHighResAsJpgButton: JQuery;
     $wholeImageLowResAsJpgButton: JQuery;
+    $wholeImageOriginalButton: JQuery;
     $entireDocumentAsDocButton: JQuery;
     $entireDocumentAsDocxButton: JQuery;
     $entireDocumentAsPdfButton: JQuery;
@@ -66,6 +67,10 @@ export class DownloadDialogue extends dialogue.Dialogue {
         this.$downloadOptions.append(this.$currentViewAsJpgButton);
         this.$currentViewAsJpgButton.hide();
 
+        this.$wholeImageOriginalButton = $('<li><input id="' + DownloadOption.wholeImageOriginal.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.wholeImageOriginal.toString() + '">' + this.content.wholeImageOriginal + '<span class="mime"></span></label></li>');
+        this.$downloadOptions.append(this.$wholeImageOriginalButton);
+        this.$wholeImageOriginalButton.hide();
+
         this.$wholeImageHighResAsJpgButton = $('<li><input id="' + DownloadOption.wholeImageHighResAsJpg.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.wholeImageHighResAsJpg.toString() + '">' + this.content.wholeImageHighResAsJpg + '</label></li>');
         this.$downloadOptions.append(this.$wholeImageHighResAsJpgButton);
         this.$wholeImageHighResAsJpgButton.hide();
@@ -112,6 +117,9 @@ export class DownloadDialogue extends dialogue.Dialogue {
                     break;
                 case DownloadOption.wholeImageLowResAsJpg.toString():
                     window.open((<ISeadragonProvider>that.provider).getConfinedImageUri(canvas, that.options.confinedImageSize));
+                    break;
+                case DownloadOption.wholeImageOriginal.toString():
+                    window.open(this.getOriginalImageForCurrentCanvas());
                     break;
                 case DownloadOption.entireDocumentAsDoc.toString():
                     window.open(this.getDocUri());
@@ -177,6 +185,18 @@ export class DownloadDialogue extends dialogue.Dialogue {
             this.$wholeImageLowResAsJpgButton.hide();
         }
 
+        if (this.isDownloadOptionAvailable(DownloadOption.wholeImageOriginal)) {
+            var mime = this.getMimeTypeForCurrentCanvas();
+            var mimeLabel = this.$wholeImageOriginalButton.find('.mime');
+            mimeLabel.empty();
+            if (mime) {
+                mimeLabel.text(' (' + mime + ')');
+            }
+            this.$wholeImageOriginalButton.show();
+        } else {
+            this.$wholeImageOriginalButton.hide();
+        }
+
         if (!this.$downloadOptions.find('li:visible').length){
             this.$noneAvailable.show();
             this.$downloadButton.hide();
@@ -199,6 +219,22 @@ export class DownloadDialogue extends dialogue.Dialogue {
 
     getSelectedOption() {
         return this.$downloadOptions.find("input:checked");
+    }
+
+    getOriginalImageForCurrentCanvas() {
+        var canvas = this.provider.getCurrentCanvas();
+        if (canvas['images'][0]['resource']['@id']) {
+            return canvas['images'][0]['resource']['@id'];
+        }
+        return false;
+    }
+
+    getMimeTypeForCurrentCanvas() {
+        var canvas = this.provider.getCurrentCanvas();
+        if (canvas['images'][0]['resource']['format']) {
+            return canvas['images'][0]['resource']['format'];
+        }
+        return false;
     }
 
     isDownloadOptionAvailable(option: DownloadOption): boolean {
@@ -235,6 +271,8 @@ export class DownloadDialogue extends dialogue.Dialogue {
                     return false;
                 }
                 return true;
+            case DownloadOption.wholeImageOriginal:
+                return (!settings.pagingEnabled && this.getOriginalImageForCurrentCanvas());
         }
     }
 

--- a/src/extensions/uv-seadragon-extension/l10n/cy-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/cy-GB.json
@@ -25,7 +25,8 @@
                 "preview": "Rhagolwg",
                 "title": "Lawrlwytho",
                 "wholeImageHighResAsJpg": "Y ddelwedd gyfan o ansawdd uchel (jpg)",
-                "wholeImageLowResAsJpg": "Y ddelwedd gyfan o ansawdd isel (jpg)"
+                "wholeImageLowResAsJpg": "Y ddelwedd gyfan o ansawdd isel (jpg)",
+                "wholeImageOriginal": "Ddelwedd wreiddiol Cyfan"
             }
         },
         "embedDialogue": {

--- a/src/extensions/uv-seadragon-extension/l10n/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/en-GB.json
@@ -27,7 +27,8 @@
                 "preview": "Preview",
                 "title": "Download",
                 "wholeImageHighResAsJpg": "Whole image high res (jpg)",
-                "wholeImageLowResAsJpg": "Whole image low res (jpg)"
+                "wholeImageLowResAsJpg": "Whole image low res (jpg)",
+                "wholeImageOriginal": "Whole original image"
             }
         },
         "embedDialogue": {

--- a/src/extensions/uv-seadragon-extension/l10n/xx-XX.json
+++ b/src/extensions/uv-seadragon-extension/l10n/xx-XX.json
@@ -24,7 +24,8 @@
                 "preview": "Preview (xx-XX)",
                 "title": "Download (xx-XX)",
                 "wholeImageHighResAsJpg": "Whole image high res (jpg) (xx-XX)",
-                "wholeImageLowResAsJpg": "Whole image low res (jpg) (xx-XX)"
+                "wholeImageLowResAsJpg": "Whole image low res (jpg) (xx-XX)",
+                "wholeImageOriginal": "Whole original image (xx-XX)"
             }
         },
         "embedDialogue": {


### PR DESCRIPTION
Presently, individual images can only be downloaded as JPEGs. We would like to also allow direct download of the TIFFs specified by our manifest for users who desire the full original image. This PR adds that functionality. I imagine that not everyone may want this. If you feel that this should be made configurable in some fashion, please let me know and I can make adjustments.