### PR TITLE
Display labels from manifest on renderings in download dialogue.

### DIFF
--- a/src/extensions/uv-seadragon-extension/downloadDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/downloadDialogue.ts
@@ -79,15 +79,21 @@ export class DownloadDialogue extends dialogue.Dialogue {
         this.$downloadOptions.append(this.$wholeImageLowResAsJpgButton);
         this.$wholeImageLowResAsJpgButton.hide();
 
-        this.$entireDocumentAsDocButton = $('<li><input id="' + DownloadOption.entireDocumentAsDoc.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsDoc.toString() + '">' + this.content.entireDocumentAsDoc + '</label></li>');
+        var docText = this.getLabelByRenderingFormat(RenderingFormat.doc);
+        docText = docText ? docText + " (doc)" : this.content.entireDocumentAsDoc;
+        this.$entireDocumentAsDocButton = $('<li><input id="' + DownloadOption.entireDocumentAsDoc.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsDoc.toString() + '">' + docText + '</label></li>');
         this.$downloadOptions.append(this.$entireDocumentAsDocButton);
         this.$entireDocumentAsDocButton.hide();
 
-        this.$entireDocumentAsDocxButton = $('<li><input id="' + DownloadOption.entireDocumentAsDocx.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsDocx.toString() + '">' + this.content.entireDocumentAsDocx + '</label></li>');
+        var docxText = this.getLabelByRenderingFormat(RenderingFormat.docx);
+        docxText = docxText ? docxText + " (docx)" : this.content.entireDocumentAsDocx;
+        this.$entireDocumentAsDocxButton = $('<li><input id="' + DownloadOption.entireDocumentAsDocx.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsDocx.toString() + '">' + docxText + '</label></li>');
         this.$downloadOptions.append(this.$entireDocumentAsDocxButton);
         this.$entireDocumentAsDocxButton.hide();
 
-        this.$entireDocumentAsPdfButton = $('<li><input id="' + DownloadOption.entireDocumentAsPDF.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsPDF.toString() + '">' + this.content.entireDocumentAsPdf + '</label></li>');
+        var pdfText = this.getLabelByRenderingFormat(RenderingFormat.pdf);
+        pdfText = pdfText ? pdfText + " (pdf)" : this.content.entireDocumentAsPdf;
+        this.$entireDocumentAsPdfButton = $('<li><input id="' + DownloadOption.entireDocumentAsPDF.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsPDF.toString() + '">' + pdfText + '</label></li>');
         this.$downloadOptions.append(this.$entireDocumentAsPdfButton);
         this.$entireDocumentAsPdfButton.hide();
 
@@ -274,6 +280,16 @@ export class DownloadDialogue extends dialogue.Dialogue {
             case DownloadOption.wholeImageOriginal:
                 return (!settings.pagingEnabled && this.getOriginalImageForCurrentCanvas());
         }
+    }
+
+    getLabelByRenderingFormat(format: RenderingFormat): string {
+        var rendering = this.provider.getRendering(this.provider.sequence, format);
+
+        if (rendering){
+            return this.provider.getLocalisedValue(rendering['label']);
+        }
+
+        return null;
     }
 
     getUriByRenderingFormat(format: RenderingFormat): string {


### PR DESCRIPTION
This is another feature that should perhaps be configurable; let me know if you'd like me to do more work on that.

This also brings up a related point: right now, the handling of PDF/Doc/Docx is very static and assumes just one file of each type. However, I could imagine situations where you might have multiple files of a single format with different labels (for example, one PDF containing all of the page images of a hand-written letter, and another PDF containing a textual transcription of the text from the letter). I suspect that rearchitecting this to allow that sort of situation might also lead to cleaner, less redundant code, but it also looks like a substantial refactoring/redesign project. I don't actually need to support this case (yet) but I might be able to find time to work on it if you'd like me to. If you have design suggestions, they would be appreciated! It looks like the Wellcome player handled this in a much simpler way by simply assembling a list of `<li>` tags. It would be nice to get back some of the flexibility that seems to have been lost by switching to the present event-based solution.