### PR TITLE
Made download dialog box more dynamic, with support for more renderings.

### DIFF
--- a/src/extensions/uv-seadragon-extension/DownloadOption.ts
+++ b/src/extensions/uv-seadragon-extension/DownloadOption.ts
@@ -1,11 +1,10 @@
 class DownloadOption {
     static currentViewAsJpg = new DownloadOption("currentViewAsJpg");
-    static entireDocumentAsDoc = new DownloadOption("entireDocumentAsDoc");
-    static entireDocumentAsDocx = new DownloadOption("entireDocumentAsDocx");
-    static entireDocumentAsPDF = new DownloadOption("entireDocumentAsPDF");
-    static wholeImageHighResAsJpg = new DownloadOption("wholeImageHighResAsJpg");
+    static dynamicCanvasRenderings = new DownloadOption("dynamicCanvasRenderings");
+    static dynamicImageRenderings = new DownloadOption("dynamicImageRenderings");
+    static dynamicSequenceRenderings = new DownloadOption("dynamicSequenceRenderings");
+    static wholeImageHighRes = new DownloadOption("wholeImageHighRes");
     static wholeImageLowResAsJpg = new DownloadOption("wholeImageLowResAsJpg");
-    static wholeImageOriginal = new DownloadOption("wholeImageOriginal");
 
     constructor(public value: string) {
     }

--- a/src/extensions/uv-seadragon-extension/downloadDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/downloadDialogue.ts
@@ -17,14 +17,12 @@ export class DownloadDialogue extends dialogue.Dialogue {
     $pagingNote: JQuery;
     $downloadOptions: JQuery;
     $currentViewAsJpgButton: JQuery;
-    $wholeImageHighResAsJpgButton: JQuery;
+    $wholeImageHighResButton: JQuery;
     $wholeImageLowResAsJpgButton: JQuery;
-    $wholeImageOriginalButton: JQuery;
-    $entireDocumentAsDocButton: JQuery;
-    $entireDocumentAsDocxButton: JQuery;
-    $entireDocumentAsPdfButton: JQuery;
     $buttonsContainer: JQuery;
     $downloadButton: JQuery;
+    renderingUrls: string[];
+    renderingUrlsCount: number;
 
     static SHOW_DOWNLOAD_DIALOGUE: string = 'onShowDownloadDialogue';
     static HIDE_DOWNLOAD_DIALOGUE: string = 'onHideDownloadDialogue';
@@ -67,35 +65,13 @@ export class DownloadDialogue extends dialogue.Dialogue {
         this.$downloadOptions.append(this.$currentViewAsJpgButton);
         this.$currentViewAsJpgButton.hide();
 
-        this.$wholeImageOriginalButton = $('<li><input id="' + DownloadOption.wholeImageOriginal.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.wholeImageOriginal.toString() + '">' + this.content.wholeImageOriginal + '<span class="mime"></span></label></li>');
-        this.$downloadOptions.append(this.$wholeImageOriginalButton);
-        this.$wholeImageOriginalButton.hide();
-
-        this.$wholeImageHighResAsJpgButton = $('<li><input id="' + DownloadOption.wholeImageHighResAsJpg.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.wholeImageHighResAsJpg.toString() + '">' + this.content.wholeImageHighResAsJpg + '</label></li>');
-        this.$downloadOptions.append(this.$wholeImageHighResAsJpgButton);
-        this.$wholeImageHighResAsJpgButton.hide();
+        this.$wholeImageHighResButton = $('<li><input id="' + DownloadOption.wholeImageHighRes.toString() + '" type="radio" name="downloadOptions" /><label id="' + DownloadOption.wholeImageHighRes.toString() + 'label" for="' + DownloadOption.wholeImageHighRes.toString() + '"></label></li>');
+        this.$downloadOptions.append(this.$wholeImageHighResButton);
+        this.$wholeImageHighResButton.hide();
 
         this.$wholeImageLowResAsJpgButton = $('<li><input id="' + DownloadOption.wholeImageLowResAsJpg.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.wholeImageLowResAsJpg.toString() + '">' + this.content.wholeImageLowResAsJpg + '</label></li>');
         this.$downloadOptions.append(this.$wholeImageLowResAsJpgButton);
         this.$wholeImageLowResAsJpgButton.hide();
-
-        var docText = this.getLabelByRenderingFormat(RenderingFormat.doc);
-        docText = docText ? docText + " (doc)" : this.content.entireDocumentAsDoc;
-        this.$entireDocumentAsDocButton = $('<li><input id="' + DownloadOption.entireDocumentAsDoc.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsDoc.toString() + '">' + docText + '</label></li>');
-        this.$downloadOptions.append(this.$entireDocumentAsDocButton);
-        this.$entireDocumentAsDocButton.hide();
-
-        var docxText = this.getLabelByRenderingFormat(RenderingFormat.docx);
-        docxText = docxText ? docxText + " (docx)" : this.content.entireDocumentAsDocx;
-        this.$entireDocumentAsDocxButton = $('<li><input id="' + DownloadOption.entireDocumentAsDocx.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsDocx.toString() + '">' + docxText + '</label></li>');
-        this.$downloadOptions.append(this.$entireDocumentAsDocxButton);
-        this.$entireDocumentAsDocxButton.hide();
-
-        var pdfText = this.getLabelByRenderingFormat(RenderingFormat.pdf);
-        pdfText = pdfText ? pdfText + " (pdf)" : this.content.entireDocumentAsPdf;
-        this.$entireDocumentAsPdfButton = $('<li><input id="' + DownloadOption.entireDocumentAsPDF.toString() + '" type="radio" name="downloadOptions" /><label for="' + DownloadOption.entireDocumentAsPDF.toString() + '">' + pdfText + '</label></li>');
-        this.$downloadOptions.append(this.$entireDocumentAsPdfButton);
-        this.$entireDocumentAsPdfButton.hide();
 
         this.$buttonsContainer = $('<div class="buttons"></div>');
         this.$content.append(this.$buttonsContainer);
@@ -113,29 +89,21 @@ export class DownloadDialogue extends dialogue.Dialogue {
             var id: string = selectedOption.attr('id');
             var canvas = this.provider.getCurrentCanvas();
 
-            switch (id){
-                case DownloadOption.currentViewAsJpg.toString():
-                    var viewer = (<ISeadragonExtension>that.extension).getViewer();
-                    window.open((<ISeadragonProvider>that.provider).getCroppedImageUri(canvas, viewer, true));
-                    break;
-                case DownloadOption.wholeImageHighResAsJpg.toString():
-                    window.open((<ISeadragonProvider>that.provider).getConfinedImageUri(canvas, canvas.width, canvas.height));
-                    break;
-                case DownloadOption.wholeImageLowResAsJpg.toString():
-                    window.open((<ISeadragonProvider>that.provider).getConfinedImageUri(canvas, that.options.confinedImageSize));
-                    break;
-                case DownloadOption.wholeImageOriginal.toString():
-                    window.open(this.getOriginalImageForCurrentCanvas());
-                    break;
-                case DownloadOption.entireDocumentAsDoc.toString():
-                    window.open(this.getDocUri());
-                    break;
-                case DownloadOption.entireDocumentAsDocx.toString():
-                    window.open(this.getDocxUri());
-                    break;
-                case DownloadOption.entireDocumentAsPDF.toString():
-                    window.open(this.getPdfUri());
-                    break;
+            if (this.renderingUrls[id]) {
+                window.open(this.renderingUrls[id]);
+            } else {
+                switch (id){
+                    case DownloadOption.currentViewAsJpg.toString():
+                        var viewer = (<ISeadragonExtension>that.extension).getViewer();
+                        window.open((<ISeadragonProvider>that.provider).getCroppedImageUri(canvas, viewer, true));
+                        break;
+                    case DownloadOption.wholeImageHighRes.toString():
+                        window.open(this.getOriginalImageForCurrentCanvas());
+                        break;
+                    case DownloadOption.wholeImageLowResAsJpg.toString():
+                        window.open((<ISeadragonProvider>that.provider).getConfinedImageUri(canvas, that.options.confinedImageSize));
+                        break;
+                }
             }
 
             $.publish(DownloadDialogue.DOWNLOAD, [id]);
@@ -161,28 +129,13 @@ export class DownloadDialogue extends dialogue.Dialogue {
             this.$currentViewAsJpgButton.hide();
         }
 
-        if (this.isDownloadOptionAvailable(DownloadOption.entireDocumentAsDoc)) {
-            this.$entireDocumentAsDocButton.show();
+        if (this.isDownloadOptionAvailable(DownloadOption.wholeImageHighRes)) {
+            var mime = this.getMimeTypeForCurrentCanvas();
+            var label = String.prototype.format(this.content.wholeImageHighRes, this.simplifyMimeType(mime));
+            $('#' + DownloadOption.wholeImageHighRes.toString() + 'label').text(label);
+            this.$wholeImageHighResButton.show();
         } else {
-            this.$entireDocumentAsDocButton.hide();
-        }
-
-        if (this.isDownloadOptionAvailable(DownloadOption.entireDocumentAsDocx)) {
-            this.$entireDocumentAsDocxButton.show();
-        } else {
-            this.$entireDocumentAsDocxButton.hide();
-        }
-
-        if (this.isDownloadOptionAvailable(DownloadOption.entireDocumentAsPDF)) {
-            this.$entireDocumentAsPdfButton.show();
-        } else {
-            this.$entireDocumentAsPdfButton.hide();
-        }
-
-        if (this.isDownloadOptionAvailable(DownloadOption.wholeImageHighResAsJpg)) {
-            this.$wholeImageHighResAsJpgButton.show();
-        } else {
-            this.$wholeImageHighResAsJpgButton.hide();
+            this.$wholeImageHighResButton.hide();
         }
 
         if (this.isDownloadOptionAvailable(DownloadOption.wholeImageLowResAsJpg)) {
@@ -191,16 +144,18 @@ export class DownloadDialogue extends dialogue.Dialogue {
             this.$wholeImageLowResAsJpgButton.hide();
         }
 
-        if (this.isDownloadOptionAvailable(DownloadOption.wholeImageOriginal)) {
-            var mime = this.getMimeTypeForCurrentCanvas();
-            var mimeLabel = this.$wholeImageOriginalButton.find('.mime');
-            mimeLabel.empty();
-            if (mime) {
-                mimeLabel.text(' (' + mime + ')');
+        this.resetDynamicDownloadOptions();
+        var currentCanvas = this.provider.getCurrentCanvas();
+        if (this.isDownloadOptionAvailable(DownloadOption.dynamicImageRenderings)) {
+            for (var i = 0; i < currentCanvas.images.length; i++) {
+                this.addDownloadOptionsForRenderings(currentCanvas.images[i], this.content.entireFileAsOriginal);
             }
-            this.$wholeImageOriginalButton.show();
-        } else {
-            this.$wholeImageOriginalButton.hide();
+        }
+        if (this.isDownloadOptionAvailable(DownloadOption.dynamicCanvasRenderings)) {
+            this.addDownloadOptionsForRenderings(currentCanvas, this.content.entireFileAsOriginal);
+        }
+        if (this.isDownloadOptionAvailable(DownloadOption.dynamicSequenceRenderings)) {
+            this.addDownloadOptionsForRenderings(this.provider.sequence, this.content.entireDocument);
         }
 
         if (!this.$downloadOptions.find('li:visible').length){
@@ -221,6 +176,56 @@ export class DownloadDialogue extends dialogue.Dialogue {
         }
 
         this.resize();
+    }
+
+    resetDynamicDownloadOptions()
+    {
+        this.renderingUrls = [];
+        this.renderingUrlsCount = 0;
+        this.$downloadOptions.find('.dynamic').remove();
+    }
+
+    simplifyMimeType(mime: string)
+    {
+        switch (mime) {
+        case 'text/plain':
+            return 'txt';
+        case 'image/jpeg':
+            return 'jpg';
+        case 'application/msword':
+            return 'doc';
+        case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
+            return 'docx';
+        default:
+            var parts = mime.split('/');
+            return parts[parts.length - 1];
+        }
+    }
+
+    addDownloadOptionsForRenderings(resource: any, defaultLabel: string)
+    {
+        var renderings = resource.rendering;
+
+        if (!$.isArray(renderings)){
+            renderings = [renderings];
+        }
+
+        for (var i = 0; i < renderings.length; i++) {
+            var rendering = renderings[i];
+            if (rendering) {
+                var label = this.provider.getLocalisedValue(rendering['label']);
+                if (label) {
+                    label += " ({0})";
+                } else {
+                    label = defaultLabel;
+                }
+                label = String.prototype.format(label, this.simplifyMimeType(rendering.format));
+                var currentId = "dynamic_download_" + ++this.renderingUrlsCount;
+                this.renderingUrls[currentId] = rendering['@id'];
+                var newButton = $('<li class="dynamic"><input id="' + currentId + '" type="radio" name="downloadOptions" /><label for="' + currentId + '">' + label + '</label></li>');
+                this.$downloadOptions.append(newButton);
+            }
+        }
     }
 
     getSelectedOption() {
@@ -248,70 +253,14 @@ export class DownloadDialogue extends dialogue.Dialogue {
 
         switch (option){
             case DownloadOption.currentViewAsJpg:
-                if (settings.pagingEnabled){
-                    return false;
-                }
-                return true;
-            case DownloadOption.entireDocumentAsDoc:
-                if (this.getDocUri()){
-                    return true;
-                }
-                return false;
-            case DownloadOption.entireDocumentAsDocx:
-                if (this.getDocxUri()){
-                    return true;
-                }
-                return false;
-            case DownloadOption.entireDocumentAsPDF:
-                if (this.getPdfUri()){
-                    return true;
-                }
-                return false;
-            case DownloadOption.wholeImageHighResAsJpg:
-                if (settings.pagingEnabled){
-                    return false;
-                }
-                return true;
+            case DownloadOption.dynamicCanvasRenderings:
+            case DownloadOption.dynamicImageRenderings:
+            case DownloadOption.wholeImageHighRes:
             case DownloadOption.wholeImageLowResAsJpg:
-                if (settings.pagingEnabled){
-                    return false;
-                }
+                return settings.pagingEnabled ? false : true;
+            default:
                 return true;
-            case DownloadOption.wholeImageOriginal:
-                return (!settings.pagingEnabled && this.getOriginalImageForCurrentCanvas());
         }
-    }
-
-    getLabelByRenderingFormat(format: RenderingFormat): string {
-        var rendering = this.provider.getRendering(this.provider.sequence, format);
-
-        if (rendering){
-            return this.provider.getLocalisedValue(rendering['label']);
-        }
-
-        return null;
-    }
-
-    getUriByRenderingFormat(format: RenderingFormat): string {
-        var rendering = this.provider.getRendering(this.provider.sequence, format);
-
-        if (rendering){
-            return rendering['@id'];
-        }
-
-        return null;
-    }
-
-    getDocUri(): string {
-        return this.getUriByRenderingFormat(RenderingFormat.doc);
-    }
-
-    getDocxUri(): string {
-        return this.getUriByRenderingFormat(RenderingFormat.docx);
-    }
-
-    getPdfUri(): string {
-        return this.getUriByRenderingFormat(RenderingFormat.pdf);
     }
 
     resize(): void {

--- a/src/extensions/uv-seadragon-extension/l10n/cy-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/cy-GB.json
@@ -16,17 +16,14 @@
                 "currentViewAsJpg": "Golwg presennol (jpg)",
                 "download": "Lawrlwytho",
                 "editSettings": "ffurfweddu gosodiadau",
-                "entireDocumentAsDoc": "Y ddogfen gyflawn (doc)",
-                "entireDocumentAsDocx": "Y ddogfen gyflawn (docx)",
-                "entireDocumentAsPdf": "Y ddogfen gyflawn (pdf)",
+                "entireDocument": "Y ddogfen gyflawn ({0})",
                 "entireFileAsOriginal": "Y ffeil gyfan ({0})",
                 "noneAvailable": "Nid oes unrhyw opsiynau lawrlwytho ar gael.",
                 "pagingNote": "Os gwelwch yn dda trowch oddi Gweld dwy dudalen ar y tro ar gyfer opsiynau ychwanegol.",
                 "preview": "Rhagolwg",
                 "title": "Lawrlwytho",
-                "wholeImageHighResAsJpg": "Y ddelwedd gyfan o ansawdd uchel (jpg)",
-                "wholeImageLowResAsJpg": "Y ddelwedd gyfan o ansawdd isel (jpg)",
-                "wholeImageOriginal": "Ddelwedd wreiddiol Cyfan"
+                "wholeImageHighRes": "Y ddelwedd gyfan o ansawdd uchel ({0})",
+                "wholeImageLowResAsJpg": "Y ddelwedd gyfan o ansawdd isel (jpg)"
             }
         },
         "embedDialogue": {

--- a/src/extensions/uv-seadragon-extension/l10n/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/en-GB.json
@@ -18,17 +18,14 @@
                 "currentViewAsJpg": "Current view (jpg)",
                 "download": "Download",
                 "editSettings": "Edit Settings",
-                "entireDocumentAsDoc": "Entire document (doc)",
-                "entireDocumentAsDocx": "Entire document (docx)",
-                "entireDocumentAsPdf": "Entire document (pdf)",
+                "entireDocument": "Entire document ({0})",
                 "entireFileAsOriginal": "Entire file ({0})",
                 "noneAvailable": "No download options are available.",
                 "pagingNote": "Please turn off Two Page View for additional options.",
                 "preview": "Preview",
                 "title": "Download",
-                "wholeImageHighResAsJpg": "Whole image high res (jpg)",
-                "wholeImageLowResAsJpg": "Whole image low res (jpg)",
-                "wholeImageOriginal": "Whole original image"
+                "wholeImageHighRes": "Whole image high res ({0})",
+                "wholeImageLowResAsJpg": "Whole image low res (jpg)"
             }
         },
         "embedDialogue": {

--- a/src/extensions/uv-seadragon-extension/l10n/xx-XX.json
+++ b/src/extensions/uv-seadragon-extension/l10n/xx-XX.json
@@ -15,17 +15,14 @@
                 "currentViewAsJpg": "Current view (jpg) (xx-XX)",
                 "download": "Download (xx-XX)",
                 "editSettings": "Edit Settings (xx-XX)",
-                "entireDocumentAsDoc": "Entire document (doc) (xx-XX)",
-                "entireDocumentAsDocx": "Entire document (docx) (xx-XX)",
-                "entireDocumentAsPdf": "Entire document (pdf) (xx-XX)",
+                "entireDocument": "Entire document ({0}) (xx-XX)",
                 "entireFileAsOriginal": "Entire file ({0}) (xx-XX)",
                 "noneAvailable": "No download options are available. (xx-XX)",
                 "pagingNote": "Please turn off Two Page View for additional options. (xx-XX)",
                 "preview": "Preview (xx-XX)",
                 "title": "Download (xx-XX)",
-                "wholeImageHighResAsJpg": "Whole image high res (jpg) (xx-XX)",
-                "wholeImageLowResAsJpg": "Whole image low res (jpg) (xx-XX)",
-                "wholeImageOriginal": "Whole original image (xx-XX)"
+                "wholeImageHighRes": "Whole image high res ({0}) (xx-XX)",
+                "wholeImageLowResAsJpg": "Whole image low res (jpg) (xx-XX)"
             }
         },
         "embedDialogue": {


### PR DESCRIPTION
This PR addresses recent discussions about dealing with original images and OCR. Here is a summary of changes:

1.) Removed separate handling of doc/docx/pdf in favor of generic handling of sequence renderings.

2.) Removed separate handling of original images in favor of generic handling of canvas/image renderings.

3.) Changed existing "high res jpg" functionality to a more generic "link to @id of image element" feature.

Notes:

- Given the way this has evolved, I'm not sure if the DownloadOption mechanism still makes sense; however, in the interest of being comparatively non-disruptive, I left it alone for the moment.

- I imagine that we might want configuration options for filtering out unwanted MIME types from the rendering lists.

- I created a simplistic routine for mapping mime-types to more human-readable versions so that dynamic labels could be more consistent with the hard-coded ones; perhaps there is a better approach, but this at least serves as a placeholder.

To-do:

- Suppress the "low res" option if it is higher resolution than the "high res" version.