### PR TITLE
Hide "low-res" option when inapplicable.

### DIFF
--- a/src/extensions/uv-seadragon-extension/downloadDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/downloadDialogue.ts
@@ -248,6 +248,14 @@ export class DownloadDialogue extends dialogue.Dialogue {
         return false;
     }
 
+    getDimensionsForCurrentCanvas() {
+        var canvas = this.provider.getCurrentCanvas();
+        if (canvas['images'][0]['resource']['width'] && canvas['images'][0]['resource']['height']) {
+            return [canvas['images'][0]['resource']['width'], canvas['images'][0]['resource']['height']];
+        }
+        return [0, 0];
+    }
+
     isDownloadOptionAvailable(option: DownloadOption): boolean {
         var settings: ISettings = this.provider.getSettings();
 
@@ -256,8 +264,11 @@ export class DownloadDialogue extends dialogue.Dialogue {
             case DownloadOption.dynamicCanvasRenderings:
             case DownloadOption.dynamicImageRenderings:
             case DownloadOption.wholeImageHighRes:
-            case DownloadOption.wholeImageLowResAsJpg:
                 return settings.pagingEnabled ? false : true;
+            case DownloadOption.wholeImageLowResAsJpg:
+                // hide low-res option if hi-res width is smaller than constraint
+                var dimensions = this.getDimensionsForCurrentCanvas();
+                return (!settings.pagingEnabled && (dimensions[0] > this.options.confinedImageSize))
             default:
                 return true;
         }


### PR DESCRIPTION
This addresses the one remaining "to do" from my previous pull request.

Now when the dimensions of the full "high res" version are smaller than the constraints used to generate the "low res" version, we hide the "low res" download link.

Arguments could be made about how the one remaining link should be labeled in this situation; it might make sense to add a new text string that says neither "high res" or "low res" since these terms are just about meaningless when not used relative to one another. However, for simplicity's sake, I just kept "high res" in the case where it's really "only res".

Also note that I'm only comparing width here, since it appears that width is the only dimension which can be constrained through the confinedImageSize setting (if I'm reading the code correctly). If we ever add more flexible constraints, we'll have to remember to adjust this dimension check to match!