### PR TITLE
Don't display "more" if the string is shorter than the character limit.

### DIFF
--- a/src/lib/jquery.plugins.js
+++ b/src/lib/jquery.plugins.js
@@ -275,6 +275,10 @@
             $trunc = $('<span></span>');
             $trunc.html($self.html().replace(/\s[\s]*/g, ' ').trim());
 
+            if ($trunc.text().trim().length <= chars) {
+                return; // do nothing if we're under the limit!
+            }
+
             while ($trunc.text().trim().length > chars) {
                 $trunc.removeLastWord(chars);
             }


### PR DESCRIPTION
The more/less logic was overzealous and would ALWAYS display a truncation control regardless of the target length of the string. This makes the control conditional, so it's only displayed when actually needed.