### PR TITLE
Fixed case problems.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -253,7 +253,7 @@ module.exports = function (grunt) {
         exec: {
             // concatenate and compress with r.js
             build: {
-                cmd: 'node lib/r.js/dist/r.js -o baseUrl=src/ mainConfigFile=src/app.js name=app <%= global.minify %> out=<%= dirs.build %>/lib/app.js'
+                cmd: 'node lib/r.js/dist/r.js -o baseUrl=src/ mainConfigFile=src/App.js name=App <%= global.minify %> out=<%= dirs.build %>/lib/app.js'
             }
         },
 


### PR DESCRIPTION
After cleaning out my directory tree and starting anew, this is the fix that seems to allow everything to build correctly without renaming any files.