### PR TITLE
Fix display of last two pages in books with odd number of canvases.

### DIFF
--- a/src/extensions/uv-seadragon-extension/Provider.ts
+++ b/src/extensions/uv-seadragon-extension/Provider.ts
@@ -172,7 +172,7 @@ class Provider extends BaseProvider implements ISeadragonProvider{
             p.tileSourceUri = this.getImageUri(this.getCurrentCanvas());
             this.pages.push(p);
         } else {
-            if (this.isFirstCanvas() || this.isLastCanvas()){
+            if (this.isFirstCanvas() || (this.isLastCanvas() && this.getTotalCanvases() % 2 == 0)){
                 var p: Page = new Page();
                 p.tileSourceUri = this.getImageUri(this.getCurrentCanvas());
                 this.pages.push(p);

--- a/src/modules/uv-shared-module/BaseProvider.ts
+++ b/src/modules/uv-shared-module/BaseProvider.ts
@@ -286,7 +286,7 @@ class BaseProvider implements IProvider{
         if (!this.isPagingSettingEnabled()) {
             indices.push(this.canvasIndex);
         } else {
-            if (this.isFirstCanvas(canvasIndex) || this.isLastCanvas(canvasIndex)){
+            if (this.isFirstCanvas(canvasIndex) || (this.isLastCanvas(canvasIndex) && this.getTotalCanvases() % 2 == 0)){
                 indices = [canvasIndex];
             } else if (canvasIndex % 2){
                 indices = [canvasIndex, canvasIndex + 1];


### PR DESCRIPTION
The logic for displaying two pages side-by-side only worked correctly in items with even numbers of canvases due to explicit assumptions about how the last page should be handled. In a book with an odd number of canvases, clicking on the last page vs. clicking on the second-to-last page would result in inconsistent behaviors, even though in this instance, the two pages should be shown side-by-side. This fix should correct the issue (I tested with both odd and even canvas counts, and both cases work correctly now).