### PR TITLE
PDF fixes

### DIFF
--- a/src/extensions/uv-pdf-extension/Commands.ts
+++ b/src/extensions/uv-pdf-extension/Commands.ts
@@ -1,7 +1,5 @@
 class Commands {
     static namespace: string = 'pdfExtension';
-
-    static THUMB_SELECTED: string                   = Commands.namespace + '.onThumbSelected';
 }
 
 export = Commands;

--- a/src/extensions/uv-pdf-extension/Extension.ts
+++ b/src/extensions/uv-pdf-extension/Extension.ts
@@ -43,7 +43,7 @@ class Extension extends BaseExtension{
 
         var that = this;
 
-        $.subscribe(Commands.THUMB_SELECTED, (e, index: number) => {
+        $.subscribe(BaseCommands.THUMB_SELECTED, (e, index: number) => {
             window.open((<IPDFProvider>that.provider).getPDFUri());
         });
 

--- a/src/extensions/uv-pdf-extension/Extension.ts
+++ b/src/extensions/uv-pdf-extension/Extension.ts
@@ -11,6 +11,7 @@ import IPDFProvider = require("./IPDFProvider");
 import IProvider = require("../../modules/uv-shared-module/IProvider");
 import LeftPanel = require("../../modules/uv-shared-module/LeftPanel");
 import MoreInfoRightPanel = require("../../modules/uv-moreinforightpanel-module/MoreInfoRightPanel");
+import Params = require("../../modules/uv-shared-module/Params");
 import PDFCenterPanel = require("../../modules/uv-pdfcenterpanel-module/PDFCenterPanel");
 import Provider = require("./Provider");
 import RightPanel = require("../../modules/uv-shared-module/RightPanel");
@@ -44,7 +45,7 @@ class Extension extends BaseExtension{
         var that = this;
 
         $.subscribe(BaseCommands.THUMB_SELECTED, (e, index: number) => {
-            window.open((<IPDFProvider>that.provider).getPDFUri());
+            this.viewFile(index);
         });
 
         $.subscribe(BaseCommands.DOWNLOAD, (e) => {
@@ -110,6 +111,19 @@ class Extension extends BaseExtension{
         if (this.isRightPanelEnabled()){
             this.rightPanel.init();
         }
+    }
+
+    viewFile(canvasIndex: number): void {
+
+        // if it's a valid canvas index.
+        if (canvasIndex == -1) return;
+
+        this.viewCanvas(canvasIndex, () => {
+            var canvas = this.provider.getCanvasByIndex(canvasIndex);
+            $.publish(BaseCommands.OPEN_MEDIA, [canvas]);
+            this.setParam(Params.canvasIndex, canvasIndex);
+        });
+
     }
 }
 

--- a/src/extensions/uv-pdf-extension/IPDFProvider.ts
+++ b/src/extensions/uv-pdf-extension/IPDFProvider.ts
@@ -3,7 +3,6 @@ import IProvider = require("../../modules/uv-shared-module/IProvider");
 
 interface IPDFProvider extends IProvider{
     getEmbedScript(width: number, height: number, embedTemplate: string): string;
-    getPDFUri(): string;
 }
 
 export = IPDFProvider;

--- a/src/extensions/uv-pdf-extension/Provider.ts
+++ b/src/extensions/uv-pdf-extension/Provider.ts
@@ -13,11 +13,6 @@ class Provider extends BaseProvider implements IPDFProvider{
         }, bootstrapper.config.options);
     }
 
-    getPDFUri(): string{
-        var canvas = this.getCanvasByIndex(0);
-        return canvas.mediaUri;
-    }
-
     getEmbedScript(width: number, height: number, embedTemplate: string): string{
 
         var esu = this.options.embedScriptUri || this.embedScriptUri;

--- a/src/extensions/uv-pdf-extension/config/en-GB.json
+++ b/src/extensions/uv-pdf-extension/config/en-GB.json
@@ -44,8 +44,10 @@
                 "titleEnabled": false
             }
         },
-        "treeViewLeftPanel": {
-
+        "treeViewLeftPanel":{
+            "options":{
+                "pageModeEnabled": true
+            }
         }
     }
 }

--- a/src/extensions/uv-seadragon-extension/Commands.ts
+++ b/src/extensions/uv-seadragon-extension/Commands.ts
@@ -24,7 +24,6 @@ class Commands {
     static SEARCH: string                           = Commands.namespace + '.onSearch';
     static SEARCH_RESULTS: string                   = Commands.namespace + '.onSearchResults';
     static SEARCH_RESULTS_EMPTY: string             = Commands.namespace + '.onSearchResultsEmpty';
-    static THUMB_SELECTED: string                   = Commands.namespace + '.onThumbSelected';
     static TREE_NODE_SELECTED: string               = Commands.namespace + '.onTreeNodeSelected';
     static VIEW_PAGE: string                        = Commands.namespace + '.onViewPage';
 }

--- a/src/extensions/uv-seadragon-extension/Extension.ts
+++ b/src/extensions/uv-seadragon-extension/Extension.ts
@@ -138,7 +138,7 @@ class Extension extends BaseExtension {
             this.treeNodeSelected(data);
         });
 
-        $.subscribe(Commands.THUMB_SELECTED, (e, index: number) => {
+        $.subscribe(BaseCommands.THUMB_SELECTED, (e, index: number) => {
             this.viewPage(index);
         });
 

--- a/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -21,7 +21,7 @@ class PDFCenterPanel extends CenterPanel {
     }
 
     viewMedia(canvas) {
-
+        var pdfUri = canvas.media[0].resource['@id'];
         var browser = window.browserDetect.browser;
         var version = window.browserDetect.version;
 
@@ -29,7 +29,7 @@ class PDFCenterPanel extends CenterPanel {
 
             // create pdf object
             var myPDF = new PDFObject({
-                url: canvas.mediaUri,
+                url: pdfUri,
                 id: "PDF"
             }).embed('content');
 
@@ -52,7 +52,7 @@ class PDFCenterPanel extends CenterPanel {
                     PDFJS.workerSrc = 'lib/pdf.worker.min.js';
                 }
 
-                PDFJS.DEFAULT_URL = canvas.media[0].resource['@id'];
+                PDFJS.DEFAULT_URL = pdfUri;
 
                 window.webViewerLoad();
 

--- a/src/modules/uv-shared-module/Commands.ts
+++ b/src/modules/uv-shared-module/Commands.ts
@@ -51,6 +51,7 @@ class Commands {
     static SHOW_MESSAGE: string                     = Commands.namespace + '.onShowMessage';
     static SHOW_OVERLAY: string                     = Commands.namespace + '.onShowOverlay';
     static SHOW_SETTINGS_DIALOGUE: string           = Commands.namespace + '.onShowSettingsDialogue';
+    static THUMB_SELECTED: string                   = Commands.namespace + '.onThumbSelected';
     static TOGGLE_FULLSCREEN: string                = Commands.namespace + '.onToggleFullScreen';
     static UP_ARROW: string                         = Commands.namespace + '.onUpArrow';
     static UPDATE_SETTINGS: string                  = Commands.namespace + '.onUpdateSettings';

--- a/src/modules/uv-treeviewleftpanel-module/GalleryView.ts
+++ b/src/modules/uv-treeviewleftpanel-module/GalleryView.ts
@@ -137,7 +137,7 @@ class GalleryView extends BaseView {
 
             that.lastThumbClickedIndex = data.index;
 
-            $.publish(Commands.THUMB_SELECTED, [data.index]);
+            $.publish(BaseCommands.THUMB_SELECTED, [data.index]);
         });
 
         this.selectIndex(this.provider.canvasIndex);

--- a/src/modules/uv-treeviewleftpanel-module/ThumbsView.ts
+++ b/src/modules/uv-treeviewleftpanel-module/ThumbsView.ts
@@ -118,7 +118,7 @@ class ThumbsView extends BaseView {
 
             that.lastThumbClickedIndex = data.index;
 
-            $.publish(Commands.THUMB_SELECTED, [data.index]);
+            $.publish(BaseCommands.THUMB_SELECTED, [data.index]);
         });
 
         this.selectIndex(this.provider.canvasIndex);


### PR DESCRIPTION
I spent a little time today learning more about the PDF module. In the process, I've made some fixes. I've left my changes as separate commits in this PR so you can see my step-by-step work, which might be easier to review than one big lump of diffs.

My main objective was to make the left sidebar work correctly so that multiple PDFs could be supported; that goal is met here. Along the way, I removed some apparently obsolete code, fixed an IE bug and moved the THUMB_SELECTED command into the shared area since I expect this will be needed by most extensions.

As always, please let me know if I can be of any help in revising my work if it is unsatisfactory.

Also note that there's still a lot more work to do here. A couple of issues I noticed along the way but have not yet had time to address:

- Thumbnails do not display appropriately in the left sidebar (probably because there aren't any image URIs in the manifest); a `<div>` is created with `height: NaNpx;`. We should find a better generic solution to missing/undefined thumbs.

- Something is not quite right with the panel logic. If you expand and collapse the left panel a few times, it gets the whole viewer into a bad state from which you cannot recover without a page refresh. It also appears that in Firefox, the PDF viewer does not adjust correctly to account for the expanded left panel, though Chrome does not display the same problem for me.

I might try to investigate these some more next week, though it will depend on available time -- I'll soon be leaving for vacation and will be out of the office from 7/2-7/13 with limited access to email.