### PR TITLE
More PDF extension fixes.

### DIFF
--- a/src/extensions/uv-pdf-extension/Extension.ts
+++ b/src/extensions/uv-pdf-extension/Extension.ts
@@ -48,6 +48,17 @@ class Extension extends BaseExtension{
             this.viewFile(index);
         });
 
+        $.subscribe(BaseCommands.LEFTPANEL_EXPAND_FULL_START, (e) => {
+            Shell.$centerPanel.hide();
+            Shell.$rightPanel.hide();
+        });
+
+        $.subscribe(BaseCommands.LEFTPANEL_COLLAPSE_FULL_FINISH, (e) => {
+            Shell.$centerPanel.show();
+            Shell.$rightPanel.show();
+            this.resize();
+        });
+
         $.subscribe(BaseCommands.DOWNLOAD, (e) => {
             $.publish(BaseCommands.SHOW_DOWNLOAD_DIALOGUE);
         });

--- a/src/extensions/uv-pdf-extension/config/en-GB.json
+++ b/src/extensions/uv-pdf-extension/config/en-GB.json
@@ -46,7 +46,23 @@
         },
         "treeViewLeftPanel":{
             "options":{
-                "pageModeEnabled": true
+                "elideCount": 40,
+                "galleryThumbHeight": 320,
+                "galleryThumbWidth": 200,
+                "oneColThumbHeight": 320,
+                "oneColThumbWidth": 200,
+                "pageModeEnabled": true,
+                "panelAnimationDuration": 250,
+                "panelCollapsedWidth": 30,
+                "panelExpandedWidth": 255,
+                "panelOpen": true,
+                "thumbsEnabled": true,
+                "thumbsExtraHeight": 8,
+                "thumbsImageFadeInDuration": 300,
+                "thumbsLoadRange": 15,
+                "treeEnabled": true,
+                "twoColThumbHeight": 150,
+                "twoColThumbWidth": 90
             }
         }
     }

--- a/src/modules/uv-treeviewleftpanel-module/GalleryView.ts
+++ b/src/modules/uv-treeviewleftpanel-module/GalleryView.ts
@@ -265,7 +265,10 @@ class GalleryView extends BaseView {
     }
 
     isPageModeEnabled(): boolean {
-        return this.config.options.pageModeEnabled && this.extension.getMode().toString() === Mode.page.toString();
+        if (typeof this.extension.getMode === "function") {
+            return this.config.options.pageModeEnabled && this.extension.getMode().toString() === Mode.page.toString();
+        }
+        return this.config.options.pageModeEnabled;
     }
 
     selectIndex(index): void {

--- a/src/modules/uv-treeviewleftpanel-module/ThumbsView.ts
+++ b/src/modules/uv-treeviewleftpanel-module/ThumbsView.ts
@@ -223,7 +223,10 @@ class ThumbsView extends BaseView {
     }
 
     isPageModeEnabled(): boolean {
-        return this.config.options.pageModeEnabled && this.extension.getMode().toString() === Mode.page.toString();
+        if (typeof this.extension.getMode === "function") {
+            return this.config.options.pageModeEnabled && this.extension.getMode().toString() === Mode.page.toString();
+        }
+        return this.config.options.pageModeEnabled;
     }
 
     selectIndex(index): void {


### PR DESCRIPTION
I believe this PR fixes the remaining major issues mentioned last week and gets the PDF extension to a bare minimum of functionality for multiple-PDF manifests:

- I fixed a fatal error caused by a call to this.extension.getMode(), when getMode() is not defined by the PDF extension. I opted to detect the presence of the method and work around it when missing rather than implementing the method in the extension, since it looked like an implementation would require loading Seadragon-specific classes into the PDF extension. Perhaps this is a sign that something isn't living in the best possible location.

- I added some missing configuration to solve the "NaN thumbnail problem" in the left sidebar. However, for now, all thumbnails show "Image Unavailable."

- I fixed the resizing behavior related to the left panel.

I still have a couple of outstanding questions/problems that you might be able to comment on:

- I'm not sure how best to deal with thumbnails in this context. Is there a mechanism for providing PDF thumbnails in the manifest? Do we have or desire the ability to specify a generic "PDF" graphic for this situation?

- The pdf.js header bar does not collapse neatly -- when the panels are expanded, controls overlap each other, and at a certain point, the header overflows the center panel and interferes with the right panel controls. I suspect this is a pdf.js problem rather than a UniversalViewer issue, but I'm not sure if we can do anything to improve the situation.

Thanks!