### PR TITLE
Allow multi-canvas media manifest.

### DIFF
--- a/src/extensions/uv-mediaelement-extension/Extension.ts
+++ b/src/extensions/uv-mediaelement-extension/Extension.ts
@@ -13,6 +13,7 @@ import HeaderPanel = require("../../modules/uv-shared-module/HeaderPanel");
 import HelpDialogue = require("../../modules/uv-dialogues-module/HelpDialogue");
 import IProvider = require("../../modules/uv-shared-module/IProvider");
 import TreeViewLeftPanel = require("../../modules/uv-treeviewleftpanel-module/TreeViewLeftPanel");
+import Params = require("../../modules/uv-shared-module/Params");
 import Provider = require("./Provider");
 import MoreInfoRightPanel = require("../../modules/uv-moreinforightpanel-module/MoreInfoRightPanel");
 import SettingsDialogue = require("./SettingsDialogue");
@@ -62,6 +63,21 @@ class Extension extends BaseExtension{
         $.subscribe(BaseCommands.EMBED, (e) => {
             $.publish(BaseCommands.SHOW_EMBED_DIALOGUE);
         });
+
+        $.subscribe(BaseCommands.THUMB_SELECTED, (e, index: number) => {
+            this.viewFile(index);
+        });
+
+        $.subscribe(BaseCommands.LEFTPANEL_EXPAND_FULL_START, (e) => {
+            Shell.$centerPanel.hide();
+            Shell.$rightPanel.hide();
+        });
+
+        $.subscribe(BaseCommands.LEFTPANEL_COLLAPSE_FULL_FINISH, (e) => {
+            Shell.$centerPanel.show();
+            Shell.$rightPanel.show();
+            this.resize();
+        });
     }
 
     createModules(): void{
@@ -106,7 +122,20 @@ class Extension extends BaseExtension{
 
     isLeftPanelEnabled(): boolean{
         return  Utils.Bools.GetBool(this.provider.config.options.leftPanelEnabled, true)
-                && this.provider.isMultiSequence();
+                && (this.provider.isMultiCanvas() || this.provider.isMultiSequence());
+    }
+
+    viewFile(canvasIndex: number): void {
+
+        // if it's a valid canvas index.
+        if (canvasIndex == -1) return;
+
+        this.viewCanvas(canvasIndex, () => {
+            var canvas = this.provider.getCanvasByIndex(canvasIndex);
+            $.publish(BaseCommands.OPEN_MEDIA, [canvas]);
+            this.setParam(Params.canvasIndex, canvasIndex);
+        });
+
     }
 }
 

--- a/src/extensions/uv-mediaelement-extension/config/en-GB.json
+++ b/src/extensions/uv-mediaelement-extension/config/en-GB.json
@@ -2,6 +2,7 @@
     "options":
     {
         "theme": "uv-en-GB-theme",
+        "leftPanelEnabled": true,
         "rightPanelEnabled": true
     },
     "modules":
@@ -44,11 +45,23 @@
         },
         "treeViewLeftPanel": {
             "options": {
+                "elideCount": 40,
+                "galleryThumbHeight": 320,
+                "galleryThumbWidth": 200,
+                "oneColThumbHeight": 320,
+                "oneColThumbWidth": 200,
+                "pageModeEnabled": true,
                 "panelAnimationDuration": 250,
                 "panelCollapsedWidth": 30,
                 "panelExpandedWidth": 255,
-                "panelOpen": false,
-                "thumbsEnabled": false
+                "panelOpen": true,
+                "thumbsEnabled": true,
+                "thumbsExtraHeight": 8,
+                "thumbsImageFadeInDuration": 300,
+                "thumbsLoadRange": 15,
+                "treeEnabled": true,
+                "twoColThumbHeight": 150,
+                "twoColThumbWidth": 90
             }
         }
     }


### PR DESCRIPTION
This PR adds support for multi-canvas audio/video (i.e. "cassette side A", "cassette side B"), with changes modeled on my recent work with the PDF extension. As with that work, this is bare minimum, and there are probably some cosmetic improvements yet to be made (such as better thumbnail options).

One question specific to this extension: there was an existing check for multiple sequences (rather than multiple canvases). I opted to OR the two options together in case the multi-sequence use case is actually necessary, but I have a suspicion this may be something legacy that is no longer meaningful. If there's a real example of a multi-sequence media manifest out there, I'd be happy to test it against this code and see if anything breaks.

Thanks!