### PR TITLE
When multiple audio sources are available, favor MP3

### DIFF
--- a/src/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
+++ b/src/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
@@ -120,7 +120,16 @@ class MediaElementCenterPanel extends CenterPanel {
             });
         } else if (canvasType.contains('sound')){
 
-            this.media = this.$container.append('<audio id="' + id + '" type="audio/mp3" src="' + sources[0].src + '" class="mejs-uv" controls="controls" preload="none" poster="' + poster + '"></audio>');
+            // Try to find an MP3, since this is most likely to work:
+            var preferredSource = 0;
+            for (var i in sources) {
+                if (sources[i].type == "audio/mp3") {
+                    preferredSource = i;
+                    break;
+                }
+            }
+
+            this.media = this.$container.append('<audio id="' + id + '" type="' + sources[preferredSource].type + '" src="' + sources[preferredSource].src + '" class="mejs-uv" controls="controls" preload="none" poster="' + poster + '"></audio>');
 
             this.player = new MediaElementPlayer("#" + id, {
                 plugins: ['flash'],


### PR DESCRIPTION
My audio manifests include renderings in several audio formats (flac/ogg/mp3). By picking the first rendering, it is possible that the viewer will attempt to play an unsupported format. This modification searches the list for audio/mp3 and only fails over to the first entry if no MP3 is found. It might make sense to extend this list to cover more audio formats or even to allow a configuration setting to set an order of preference for formats. However, this simple fix is good enough for my local needs.