### PR TITLE
Undo case switch.

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
 <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <head>
     <script type="text/javascript" src="lib/easyXDM.min.js"></script>
-    <script data-main="App" type="text/javascript" src="lib/require.js"></script>
+    <script data-main="app" type="text/javascript" src="lib/require.js"></script>
     <style type="text/css">
         #app.loading {
             background-repeat: no-repeat;


### PR DESCRIPTION
I am thoroughly confused about what is going on here. After you merged my pull request and I pulled down the latest master (totally resetting everything, deleting all files, reinstalling dependencies, etc.) I found myself encountering case sensitivity problems yet again. Putting it back the way it was got it working again. I'm not sure what could have changed!

The previous time that I was encountering problems (when I changed "app" to "App") the failure had to do with the browser attempting to load src/App.js. But this time (when I'm changing "App" back to "app") the problem had to do with the browser attempting to load App.js from inside the built application, where the filename is actually app.js.

I've tried to be consistent in my procedures for resetting and building, so I'm not sure what caused the change in behavior. In any case, I've now written a shell script to fully automate the resetting of my UV checkout, so that should eliminate several layers of potential human error from my process in the future.

In any case, apologies for all the back and forth. Hopefully it's actually right this time!

And is there any strong reason for having App in some places and app in others? It's obviously making the whole thing a bit more error-prone than it might otherwise be.