### PR TITLE
Fixed problem with ID being included in base URI.

### DIFF
--- a/src/extensions/uv-seadragon-extension/Provider.ts
+++ b/src/extensions/uv-seadragon-extension/Provider.ts
@@ -112,14 +112,16 @@ class Provider extends BaseProvider implements ISeadragonProvider{
 
     getImageId(canvas: any): string {
         var id = this.getImageUri(canvas);
+        // First trim off info.json, then extract ID:
         id = id.substr(0, id.lastIndexOf("/"));
         return id.substr(id.lastIndexOf("/") + 1);
     }
 
     getImageBaseUri(canvas: any): string {
         var uri = this.getImageUri(canvas);
+        // First trim off info.json, then trim off ID....
         uri = uri.substr(0, uri.lastIndexOf("/"));
-        return uri;
+        return uri.substr(0, uri.lastIndexOf("/"));
     }
 
     getImageUri(canvas: any): string{


### PR DESCRIPTION
I just noticed that the "current view" and "whole image low res" download options were not working in the latest master. These were working a couple of weeks ago, prior to my vacation. It appears that the issue is that getBaseUri was including the image ID when it shouldn't have, which was resulting in invalid IIIF URIs with doubled-up ID values in them. I believe that this PR should fix the problem, though I'm not sure when/where/why the bug was originally introduced.