### PR TITLE
Add config setting to disable pdf.js.

### DIFF
--- a/src/extensions/uv-pdf-extension/config/en-GB.json
+++ b/src/extensions/uv-pdf-extension/config/en-GB.json
@@ -43,7 +43,8 @@
     "pdfCenterPanel":
     {
       "options":{
-        "titleEnabled": false
+        "titleEnabled": false,
+        "usePdfJs": true
       }
     },
     "treeViewLeftPanel":{

--- a/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -25,7 +25,7 @@ class PDFCenterPanel extends CenterPanel {
         var browser = window.browserDetect.browser;
         var version = window.browserDetect.version;
 
-        if (browser === 'Explorer' && version < 10) {
+        if ((browser === 'Explorer' && version < 10) || !this.config.options.usePdfJs) {
 
             // create pdf object
             var myPDF = new PDFObject({


### PR DESCRIPTION
Our collection contains several PDF files that the pdf.js code included with UV is unable to render correctly. However, the PDFObject method, while slower, appears to have better broad-spectrum compatibility. Thus, I have added a configuration setting to optionally disable pdf.js.

As time permits, I still plan to do some more work to upgrade pdf.js and see if I can track down the root cause of the problems. Given that pdf.js is built into Firefox natively, there has to be an explanation as to why that version works fine but the one bundled in UV breaks.