### PR TITLE
Working tests in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,16 @@ node_js:
 before_install:
 - npm install -g grunt-cli
 - npm install -g bower
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+- curl -Lo chrome.zip https://download-chromium.appspot.com/dl/Linux_x64 && unzip chrome.zip
 install:
 - npm install
 - bower install
+before_script:
+- ./node_modules/protractor/bin/webdriver-manager update
+- ./node_modules/protractor/bin/webdriver-manager start &
 script:
 - grunt build
+- grunt serve &
+- grunt test


### PR DESCRIPTION
Tests are working!

This may be a bit fragile for two reasons:

1.) Travis doesn't support Chrome by default, and the new container infrastructure doesn't make it easy to install, so we have to download the compiled binary from a fixed location.

2.) This binary distribution has problems with the sandbox, so we have to use the --no-sandbox switch (bad security practice, but in this context I don't think we care). I tried to work around this in other ways but didn't find an easy fix.

Bottom line: it works, but it might eventually stop working. I figure we can cross that bridge when we come to it!