### PR TITLE
Don't try to set a poster attribute if no poster exists.

### DIFF
--- a/src/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
+++ b/src/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
@@ -74,6 +74,7 @@ class MediaElementCenterPanel extends CenterPanel {
 
             var id = Utils.Dates.GetTimeStamp();
             var poster = (<IMediaElementProvider>this.provider).getPosterImageUri();
+            var posterAttr: string = poster ? ' poster="' + poster + '"' : '';
 
             var sources = [];
 
@@ -86,7 +87,7 @@ class MediaElementCenterPanel extends CenterPanel {
 
             if (this.isVideo(canvas)){
 
-                this.media = this.$container.append('<video id="' + id + '" type="video/mp4" class="mejs-uv" controls="controls" preload="none" poster="' + poster + '"></video>');
+                this.media = this.$container.append('<video id="' + id + '" type="video/mp4" class="mejs-uv" controls="controls" preload="none"' + posterAttr + '></video>');
 
                 this.player = new MediaElementPlayer("#" + id, {
                     type: ['video/mp4', 'video/webm', 'video/flv'],
@@ -133,7 +134,7 @@ class MediaElementCenterPanel extends CenterPanel {
                     }
                 }
 
-                this.media = this.$container.append('<audio id="' + id + '" type="' + sources[preferredSource].type + '" src="' + sources[preferredSource].src + '" class="mejs-uv" controls="controls" preload="none" poster="' + poster + '"></audio>');
+                this.media = this.$container.append('<audio id="' + id + '" type="' + sources[preferredSource].type + '" src="' + sources[preferredSource].src + '" class="mejs-uv" controls="controls" preload="none"' + posterAttr + '></audio>');
 
                 this.player = new MediaElementPlayer("#" + id, {
                     plugins: ['flash'],


### PR DESCRIPTION
My audio manifests don't currently include thumbnails. This was causing a 404 error for an image called "undefined." I adjusted the code to only include the poster attribute if a poster image URI is found.

This appears to work fine with the "Florence Nightingale" Wellcome example, so I think both with-thumb and without-thumb cases are now properly handled.