### PR TITLE
Fix crash on navigation if currentBounds wasn't set.

### DIFF
--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -357,7 +357,7 @@ class SeadragonCenterPanel extends CenterPanel {
             var settings: ISettings = this.provider.getSettings();
 
             // zoom to bounds unless setting disabled
-            if (settings.preserveViewport){
+            if (settings.preserveViewport && this.currentBounds){
                 this.fitToBounds(this.currentBounds);
             } else {
                 this.goHome();


### PR DESCRIPTION
Hi!

This is a fix for a crash that occurred for us with certain images. If you didn't touch the image after load and directly tried to navigate to the next one, currentBounds wasn't set and threw an exception.