### PR TITLE
Removed the OSD element outline 

### DIFF
--- a/src/modules/uv-seadragoncenterpanel-module/css/styles.less
+++ b/src/modules/uv-seadragoncenterpanel-module/css/styles.less
@@ -166,4 +166,8 @@
             }
         }
     }
+
+    .openseadragon-canvas {
+        outline: none;
+    }
 }


### PR DESCRIPTION
If you click inside the OSD canvas but beside the image a blue or dotted line appears all around the OSD canvas, this patch removes that line.