### PR TITLE
Fixed port for use with https.

### DIFF
--- a/src/lib/manifesto.js
+++ b/src/lib/manifesto.js
@@ -1498,7 +1498,7 @@ var Manifesto;
                 var u = url.parse(uri);
                 var fetch = http.request({
                     host: u.hostname,
-                    port: u.port || 80,
+                    port: u.port,
                     path: u.pathname,
                     method: "GET",
                     withCredentials: false


### PR DESCRIPTION
Hi,

I just integrated UniversalViewer in Omeka (beta https://github.com/Daniel-KM/UniversalViewer4Omeka) and I find a small bug because a site of mine is under https: https://patrimoine.mines-paristech.fr/collections/play/7.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
