### PR TITLE
Basic mechanism for displaying text links for licenses.

### DIFF
--- a/src/extensions/uv-mediaelement-extension/l10n/en-GB.json
+++ b/src/extensions/uv-mediaelement-extension/l10n/en-GB.json
@@ -6,6 +6,32 @@
     "degradedResourceMessage": "Please log in to view at full quality.",
     "degradedResourceLogin": "log in"
   },
+  "license": {
+    "http://creativecommons.org/licenses/by/1.0/": "Creative Commons Attribution 1.0 Generic (CC BY 1.0)",
+    "http://creativecommons.org/licenses/by-nc/1.0/": "Creative Commons Attribution-NonCommercial 1.0 Generic (CC BY-NC 1.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/1.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 1.0 Generic (CC BY-NC-ND 1.0)",
+    "http://creativecommons.org/licenses/by-nd/1.0/": "Creative Commons Attribution-NoDerivs 1.0 Generic (CC BY-ND 1.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/1.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 1.0 Generic (CC BY-NC-SA 1.0)",
+    "http://creativecommons.org/licenses/by-sa/1.0/": "Creative Commons Attribution-ShareAlike 1.0 Generic (CC BY-SA 1.0)",
+    "http://creativecommons.org/licenses/by/2.0/": "Creative Commons Attribution 2.0 Generic (CC BY 2.0)",
+    "http://creativecommons.org/licenses/by-nc/2.0/": "Creative Commons Attribution-NonCommercial 2.0 Generic (CC BY-NC 2.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/2.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 2.0 Generic (CC BY-NC-ND 2.0)",
+    "http://creativecommons.org/licenses/by-nd/2.0/": "Creative Commons Attribution-NoDerivs 2.0 Generic (CC BY-ND 2.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/2.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 Generic (CC BY-NC-SA 2.0)",
+    "http://creativecommons.org/licenses/by-sa/2.0/": "Creative Commons Attribution-ShareAlike 2.0 Generic (CC BY-SA 2.0)",
+    "http://creativecommons.org/licenses/by/3.0/": "Creative Commons Attribution 3.0 Unported (CC BY 3.0)",
+    "http://creativecommons.org/licenses/by-nc/3.0/": "Creative Commons Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/3.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported (CC BY-NC-ND 3.0)",
+    "http://creativecommons.org/licenses/by-nd/3.0/": "Creative Commons Attribution-NoDerivs 3.0 Unported (CC BY-ND 3.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/3.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)",
+    "http://creativecommons.org/licenses/by-sa/3.0/": "Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)",
+    "http://creativecommons.org/licenses/by/4.0/": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
+    "http://creativecommons.org/licenses/by-nc/4.0/": "Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/4.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 4.0 International (CC BY-NC-ND 4.0)",
+    "http://creativecommons.org/licenses/by-nd/4.0/": "Creative Commons Attribution-NoDerivs 4.0 International (CC BY-ND 4.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/4.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)",
+    "http://creativecommons.org/licenses/by-sa/4.0/": "Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)"
+  },
   "modules": {
     "dialogue": {
       "content": {

--- a/src/extensions/uv-pdf-extension/l10n/en-GB.json
+++ b/src/extensions/uv-pdf-extension/l10n/en-GB.json
@@ -6,6 +6,32 @@
     "degradedResourceMessage": "Please log in to view at full quality.",
     "degradedResourceLogin": "log in"
   },
+  "license": {
+    "http://creativecommons.org/licenses/by/1.0/": "Creative Commons Attribution 1.0 Generic (CC BY 1.0)",
+    "http://creativecommons.org/licenses/by-nc/1.0/": "Creative Commons Attribution-NonCommercial 1.0 Generic (CC BY-NC 1.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/1.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 1.0 Generic (CC BY-NC-ND 1.0)",
+    "http://creativecommons.org/licenses/by-nd/1.0/": "Creative Commons Attribution-NoDerivs 1.0 Generic (CC BY-ND 1.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/1.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 1.0 Generic (CC BY-NC-SA 1.0)",
+    "http://creativecommons.org/licenses/by-sa/1.0/": "Creative Commons Attribution-ShareAlike 1.0 Generic (CC BY-SA 1.0)",
+    "http://creativecommons.org/licenses/by/2.0/": "Creative Commons Attribution 2.0 Generic (CC BY 2.0)",
+    "http://creativecommons.org/licenses/by-nc/2.0/": "Creative Commons Attribution-NonCommercial 2.0 Generic (CC BY-NC 2.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/2.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 2.0 Generic (CC BY-NC-ND 2.0)",
+    "http://creativecommons.org/licenses/by-nd/2.0/": "Creative Commons Attribution-NoDerivs 2.0 Generic (CC BY-ND 2.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/2.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 Generic (CC BY-NC-SA 2.0)",
+    "http://creativecommons.org/licenses/by-sa/2.0/": "Creative Commons Attribution-ShareAlike 2.0 Generic (CC BY-SA 2.0)",
+    "http://creativecommons.org/licenses/by/3.0/": "Creative Commons Attribution 3.0 Unported (CC BY 3.0)",
+    "http://creativecommons.org/licenses/by-nc/3.0/": "Creative Commons Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/3.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported (CC BY-NC-ND 3.0)",
+    "http://creativecommons.org/licenses/by-nd/3.0/": "Creative Commons Attribution-NoDerivs 3.0 Unported (CC BY-ND 3.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/3.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)",
+    "http://creativecommons.org/licenses/by-sa/3.0/": "Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)",
+    "http://creativecommons.org/licenses/by/4.0/": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
+    "http://creativecommons.org/licenses/by-nc/4.0/": "Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/4.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 4.0 International (CC BY-NC-ND 4.0)",
+    "http://creativecommons.org/licenses/by-nd/4.0/": "Creative Commons Attribution-NoDerivs 4.0 International (CC BY-ND 4.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/4.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)",
+    "http://creativecommons.org/licenses/by-sa/4.0/": "Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)"
+  },
   "modules": {
     "dialogue": {
       "content": {

--- a/src/extensions/uv-seadragon-extension/l10n/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/en-GB.json
@@ -9,6 +9,32 @@
     "degradedResourceMessage": "Please log in to view at full quality.",
     "degradedResourceLogin": "log in"
   },
+  "license": {
+    "http://creativecommons.org/licenses/by/1.0/": "Creative Commons Attribution 1.0 Generic (CC BY 1.0)",
+    "http://creativecommons.org/licenses/by-nc/1.0/": "Creative Commons Attribution-NonCommercial 1.0 Generic (CC BY-NC 1.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/1.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 1.0 Generic (CC BY-NC-ND 1.0)",
+    "http://creativecommons.org/licenses/by-nd/1.0/": "Creative Commons Attribution-NoDerivs 1.0 Generic (CC BY-ND 1.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/1.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 1.0 Generic (CC BY-NC-SA 1.0)",
+    "http://creativecommons.org/licenses/by-sa/1.0/": "Creative Commons Attribution-ShareAlike 1.0 Generic (CC BY-SA 1.0)",
+    "http://creativecommons.org/licenses/by/2.0/": "Creative Commons Attribution 2.0 Generic (CC BY 2.0)",
+    "http://creativecommons.org/licenses/by-nc/2.0/": "Creative Commons Attribution-NonCommercial 2.0 Generic (CC BY-NC 2.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/2.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 2.0 Generic (CC BY-NC-ND 2.0)",
+    "http://creativecommons.org/licenses/by-nd/2.0/": "Creative Commons Attribution-NoDerivs 2.0 Generic (CC BY-ND 2.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/2.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 Generic (CC BY-NC-SA 2.0)",
+    "http://creativecommons.org/licenses/by-sa/2.0/": "Creative Commons Attribution-ShareAlike 2.0 Generic (CC BY-SA 2.0)",
+    "http://creativecommons.org/licenses/by/3.0/": "Creative Commons Attribution 3.0 Unported (CC BY 3.0)",
+    "http://creativecommons.org/licenses/by-nc/3.0/": "Creative Commons Attribution-NonCommercial 3.0 Unported (CC BY-NC 3.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/3.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 3.0 Unported (CC BY-NC-ND 3.0)",
+    "http://creativecommons.org/licenses/by-nd/3.0/": "Creative Commons Attribution-NoDerivs 3.0 Unported (CC BY-ND 3.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/3.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported (CC BY-NC-SA 3.0)",
+    "http://creativecommons.org/licenses/by-sa/3.0/": "Creative Commons Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)",
+    "http://creativecommons.org/licenses/by/4.0/": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
+    "http://creativecommons.org/licenses/by-nc/4.0/": "Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)",
+    "http://creativecommons.org/licenses/by-nc-nd/4.0/": "Creative Commons Attribution-NonCommercial-NoDerivs 4.0 International (CC BY-NC-ND 4.0)",
+    "http://creativecommons.org/licenses/by-nd/4.0/": "Creative Commons Attribution-NoDerivs 4.0 International (CC BY-ND 4.0)",
+    "http://creativecommons.org/licenses/by-nc-sa/4.0/": "Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)",
+    "http://creativecommons.org/licenses/by-sa/4.0/": "Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)"
+  },
   "modules": {
     "clickThroughDialogue": {
       "content": {

--- a/src/modules/uv-shared-module/BaseProvider.ts
+++ b/src/modules/uv-shared-module/BaseProvider.ts
@@ -4,6 +4,7 @@ import ExternalResource = require("./ExternalResource");
 import IProvider = require("./IProvider");
 import Params = require("../../Params");
 import Storage = require("./Storage");
+import UriLabeller = require("./UriLabeller");
 
 // providers contain methods that could be implemented differently according
 // to factors like varying back end data provisioning systems.
@@ -23,6 +24,7 @@ class BaseProvider implements IProvider{
     isOnlyInstance: boolean;
     isReload: boolean;
     jsonp: boolean;
+    licenseFormatter: UriLabeller;
     locale: string;
     locales: any[];
     manifest: Manifesto.IManifest;
@@ -62,6 +64,8 @@ class BaseProvider implements IProvider{
         this.manifestIndex = this.bootstrapper.params.manifestIndex;
         this.sequenceIndex = this.bootstrapper.params.sequenceIndex;
         this.canvasIndex = this.bootstrapper.params.canvasIndex;
+
+        this.licenseFormatter = new UriLabeller(this.config.license ? this.config.license : {});
     }
 
     // re-bootstraps the application with new querystring params
@@ -338,7 +342,7 @@ class BaseProvider implements IProvider{
         if (this.manifest.getLicense()){
             metadata.unshift({
                 "label": "license",
-                "value": this.manifest.getLicense()
+                "value": this.licenseFormatter.format(this.manifest.getLicense())
             });
         }
 

--- a/src/modules/uv-shared-module/UriLabeller.ts
+++ b/src/modules/uv-shared-module/UriLabeller.ts
@@ -1,0 +1,15 @@
+// This class formats URIs into HTML <a> links, applying labels when available
+class UriLabeller {
+    labels: Object;
+
+    constructor(labels: Object) {
+        this.labels = labels;
+    }
+
+    format(url): string {
+        var label = this.labels[url] ? this.labels[url] : url;
+        return '<a href="' + url + '">' + label + '</a>';
+    }
+};
+
+export = UriLabeller;


### PR DESCRIPTION
This is intended as a proof of concept -- I don't think it's useful to merge as-is.

The idea is that we want to be able to display descriptions associated with the license URLs. I've just populated this with a single URL to allow the "Bride of the Tomb" example to work correctly. Ideally I think we would want the labels to account for i18n and be able to easily pull from local configuration... but I wasn't sure how to address that all the way down at the BaseProvider level where we need it.

Thoughts?