### PR TITLE
Avoid fatal error when getSortedTree() is undefined.

### DIFF
--- a/src/modules/uv-treeviewleftpanel-module/TreeViewLeftPanel.ts
+++ b/src/modules/uv-treeviewleftpanel-module/TreeViewLeftPanel.ts
@@ -220,9 +220,11 @@ class TreeViewLeftPanel extends LeftPanel {
             var treeEnabled = Utils.Bools.GetBool(this.config.options.treeEnabled, true);
             var thumbsEnabled = Utils.Bools.GetBool(this.config.options.thumbsEnabled, true);
 
-            this.treeData = (<ISeadragonProvider>this.provider).getSortedTree(TreeSortType.none);
+            this.treeData = (typeof (<ISeadragonProvider>this.provider).getSortedTree === 'function')
+                ? (<ISeadragonProvider>this.provider).getSortedTree(TreeSortType.none)
+                : null;
 
-            if (!this.treeData.nodes.length) {
+            if (!this.treeData || !this.treeData.nodes.length) {
                 treeEnabled = false;
             }
 


### PR DESCRIPTION
- Prevents errors in non-Seadragon extensions.