### PR TITLE
Using keyboard to navigate in OSD

### DIFF
--- a/src/extensions/uv-seadragon-extension/Extension.ts
+++ b/src/extensions/uv-seadragon-extension/Extension.ts
@@ -111,12 +111,28 @@ class Extension extends BaseExtension {
             this.viewPage(this.provider.getNextPageIndex());
         });
 
+        $.subscribe(BaseCommands.UP_ARROW, (e) => {
+            if (!this.useArrowKeysToNavigate())
+                this.centerPanel.setFocus();
+        });
+
+        $.subscribe(BaseCommands.DOWN_ARROW, (e) => {
+            if (!this.useArrowKeysToNavigate())
+                this.centerPanel.setFocus();
+        });
+
         $.subscribe(BaseCommands.LEFT_ARROW, (e) => {
-            this.viewPage(this.provider.getPrevPageIndex());
+            if (this.useArrowKeysToNavigate())
+                this.viewPage(this.provider.getPrevPageIndex());
+            else
+                this.centerPanel.setFocus();
         });
 
         $.subscribe(BaseCommands.RIGHT_ARROW, (e) => {
-            this.viewPage(this.provider.getNextPageIndex());
+            if (this.useArrowKeysToNavigate())
+                this.viewPage(this.provider.getNextPageIndex());
+            else
+                this.centerPanel.setFocus();
         });
 
         $.subscribe(Commands.MODE_CHANGED, (e, mode: string) => {
@@ -195,7 +211,8 @@ class Extension extends BaseExtension {
         });
 
         $.subscribe(Commands.SEADRAGON_OPEN, () => {
-
+            if (!this.useArrowKeysToNavigate())
+                this.centerPanel.setFocus();
         });
 
         $.subscribe(Commands.SEADRAGON_ROTATION, (e, rotation) => {
@@ -203,6 +220,8 @@ class Extension extends BaseExtension {
             this.currentRotation = rotation;
             this.setParam(Params.rotation, rotation);
         });
+
+        
     }
 
     createModules(): void{

--- a/src/extensions/uv-seadragon-extension/Extension.ts
+++ b/src/extensions/uv-seadragon-extension/Extension.ts
@@ -111,6 +111,14 @@ class Extension extends BaseExtension {
             this.viewPage(this.provider.getNextPageIndex());
         });
 
+        $.subscribe(BaseCommands.PLUS, (e) => {
+            this.centerPanel.setFocus();
+        });
+
+        $.subscribe(BaseCommands.MINUS, (e) => {
+            this.centerPanel.setFocus();
+        });
+
         $.subscribe(BaseCommands.UP_ARROW, (e) => {
             if (!this.useArrowKeysToNavigate())
                 this.centerPanel.setFocus();

--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -9,7 +9,8 @@
     "preserveViewport": false,
     "rightPanelEnabled": true,
     "searchWithinEnabled": true,
-    "theme": "uv-en-GB-theme"
+    "theme": "uv-en-GB-theme",
+    "useArrowKeysToNavigate": true
   },
   "modules":
   {

--- a/src/extensions/uv-seadragon-extension/lib/openseadragon.js
+++ b/src/extensions/uv-seadragon-extension/lib/openseadragon.js
@@ -8854,6 +8854,7 @@ window.OpenSeadragon = window.OpenSeadragon || function( options ){
     function onCanvasKeyPress( event ) {
         if ( !event.preventDefaultAction && !event.ctrl && !event.alt && !event.meta ) {
             switch( event.keyCode ){
+                case 43://=|+
                 case 61://=|+
                     this.viewport.zoomBy(1.1);
                     this.viewport.applyConstraints();

--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -605,5 +605,12 @@ class SeadragonCenterPanel extends CenterPanel {
             this.$rights.css('top', this.$content.height() - this.$rights.outerHeight() - this.$rights.verticalMargins());
         }
     }
+
+    setFocus(): void {
+        var $canvas = $(this.viewer.canvas);
+
+        if (!$canvas.is(":focus"))
+            $canvas.focus();
+    }
 }
 export = SeadragonCenterPanel;

--- a/src/modules/uv-shared-module/BaseCommands.ts
+++ b/src/modules/uv-shared-module/BaseCommands.ts
@@ -63,6 +63,8 @@ class Commands {
     static UPDATE_SETTINGS: string                  = Commands.namespace + 'onUpdateSettings';
     static VIEW_FULL_TERMS: string                  = Commands.namespace + 'onViewFullTerms';
     static WINDOW_UNLOAD: string                    = Commands.namespace + 'onWindowUnload';
+    static PLUS: string                             = Commands.namespace + 'onPlus';
+    static MINUS: string                            = Commands.namespace + 'onMinus';
 }
 
 export = Commands;

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -143,6 +143,10 @@ class BaseExtension implements IExtension {
 
             if (!this.useArrowKeysToNavigate()) {
                 $(document).keydown((e) => {
+                    //Prevent home, end, page up and page down from scrolling the window.
+                    if (e.keyCode === 33 || e.keyCode === 34 || e.keyCode === 35 || e.keyCode === 36)
+                        e.preventDefault();
+
                     var event: string = null;
 
                     if (e.keyCode === 37) event = BaseCommands.LEFT_ARROW;

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -141,25 +141,35 @@ class BaseExtension implements IExtension {
                 }
             });
 
-            if (!this.useArrowKeysToNavigate()) {
-                $(document).keydown((e) => {
-                    //Prevent home, end, page up and page down from scrolling the window.
-                    if (e.keyCode === 33 || e.keyCode === 34 || e.keyCode === 35 || e.keyCode === 36)
-                        e.preventDefault();
+            
+            $(document).keydown((e) => {
+                //Prevent home, end, page up and page down from scrolling the window.
+                if (e.keyCode === 33 || e.keyCode === 34 || e.keyCode === 35 || e.keyCode === 36)
+                    e.preventDefault();
 
-                    var event: string = null;
+                var event: string = null;
+
+                if (!this.useArrowKeysToNavigate()) {
+                    //Prevent arrow keys from their default action.
+                    if (e.keyCode === 37 || e.keyCode === 38 || e.keyCode === 39 || e.keyCode === 40)
+                        e.preventDefault();
 
                     if (e.keyCode === 37) event = BaseCommands.LEFT_ARROW;
                     if (e.keyCode === 38) event = BaseCommands.UP_ARROW;
                     if (e.keyCode === 39) event = BaseCommands.RIGHT_ARROW;
                     if (e.keyCode === 40) event = BaseCommands.DOWN_ARROW;
+                }
 
-                    if (event) {
-                        e.preventDefault();
-                        $.publish(event);
-                    }
-                });
-            }
+                if (e.keyCode === 107 || e.keyCode === 171 || e.keyCode === 187)
+                    event = BaseCommands.PLUS;
+                if (e.keyCode === 109 || e.keyCode === 173 || e.keyCode === 189)
+                    event = BaseCommands.MINUS;
+
+                if (event) {
+                    $.publish(event);
+                }
+            });
+            
 
             $(parent.document).on('fullscreenchange webkitfullscreenchange mozfullscreenchange MSFullscreenChange', (e) => {
                 if (e.type === 'webkitfullscreenchange' && !parent.document.webkitIsFullScreen ||

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -141,6 +141,22 @@ class BaseExtension implements IExtension {
                 }
             });
 
+            if (!this.useArrowKeysToNavigate()) {
+                $(document).keydown((e) => {
+                    var event: string = null;
+
+                    if (e.keyCode === 37) event = BaseCommands.LEFT_ARROW;
+                    if (e.keyCode === 38) event = BaseCommands.UP_ARROW;
+                    if (e.keyCode === 39) event = BaseCommands.RIGHT_ARROW;
+                    if (e.keyCode === 40) event = BaseCommands.DOWN_ARROW;
+
+                    if (event) {
+                        e.preventDefault();
+                        $.publish(event);
+                    }
+                });
+            }
+
             $(parent.document).on('fullscreenchange webkitfullscreenchange mozfullscreenchange MSFullscreenChange', (e) => {
                 if (e.type === 'webkitfullscreenchange' && !parent.document.webkitIsFullScreen ||
                     e.type === 'mozfullscreenchange' && !parent.document.mozFullScreen ||
@@ -694,6 +710,10 @@ class BaseExtension implements IExtension {
 
     isRightPanelEnabled(): boolean{
         return  Utils.Bools.GetBool(this.provider.config.options.rightPanelEnabled, true);
+    }
+
+    useArrowKeysToNavigate(): boolean {
+        return Utils.Bools.GetBool(this.provider.config.options.useArrowKeysToNavigate, true);
     }
 
     // auth


### PR DESCRIPTION
Hi!

This is a patch to use the arrow keys for scrolling in OSD instead of changing page. I've added the config option "useArrowKeysToNavigate" which defaults to true and then has the current behavior of switching page.

I've also made some fixes to make plus and minus keys zoom OSD properly, and to prevent home, end, page up and page down from scrolling the browser window when UV has focus.

Part of the zoom problem is with OSD, I've made a pull request with them but also fixed it in the compiled version in UV. https://github.com/openseadragon/openseadragon/pull/763

Sorry for the code being kind of bungled up in to one pull request.

Also, do you have any plans of updating OSD to the latest version? We are testing with master now and it seems to be running fine and seems to load images a bit faster. I've seen they are planning to release version 2.1 later this week or the next one.