### PR TITLE
Option to use arrow keys for scrolling in OSD

### DIFF
--- a/src/extensions/uv-seadragon-extension/Extension.ts
+++ b/src/extensions/uv-seadragon-extension/Extension.ts
@@ -111,12 +111,28 @@ class Extension extends BaseExtension {
             this.viewPage(this.provider.getNextPageIndex());
         });
 
+        $.subscribe(BaseCommands.UP_ARROW, (e) => {
+            if (!this.useArrowKeysToNavigate())
+                this.centerPanel.setFocus();
+        });
+
+        $.subscribe(BaseCommands.DOWN_ARROW, (e) => {
+            if (!this.useArrowKeysToNavigate())
+                this.centerPanel.setFocus();
+        });
+
         $.subscribe(BaseCommands.LEFT_ARROW, (e) => {
-            this.viewPage(this.provider.getPrevPageIndex());
+            if (this.useArrowKeysToNavigate())
+                this.viewPage(this.provider.getPrevPageIndex());
+            else
+                this.centerPanel.setFocus();
         });
 
         $.subscribe(BaseCommands.RIGHT_ARROW, (e) => {
-            this.viewPage(this.provider.getNextPageIndex());
+            if (this.useArrowKeysToNavigate())
+                this.viewPage(this.provider.getNextPageIndex());
+            else
+                this.centerPanel.setFocus();
         });
 
         $.subscribe(Commands.MODE_CHANGED, (e, mode: string) => {
@@ -195,7 +211,8 @@ class Extension extends BaseExtension {
         });
 
         $.subscribe(Commands.SEADRAGON_OPEN, () => {
-
+            if (!this.useArrowKeysToNavigate())
+                this.centerPanel.setFocus();
         });
 
         $.subscribe(Commands.SEADRAGON_ROTATION, (e, rotation) => {
@@ -203,6 +220,8 @@ class Extension extends BaseExtension {
             this.currentRotation = rotation;
             this.setParam(Params.rotation, rotation);
         });
+
+        
     }
 
     createModules(): void{

--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -9,7 +9,8 @@
     "preserveViewport": false,
     "rightPanelEnabled": true,
     "searchWithinEnabled": true,
-    "theme": "uv-en-GB-theme"
+    "theme": "uv-en-GB-theme",
+    "useArrowKeysToNavigate": true
   },
   "modules":
   {

--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -605,5 +605,12 @@ class SeadragonCenterPanel extends CenterPanel {
             this.$rights.css('top', this.$content.height() - this.$rights.outerHeight() - this.$rights.verticalMargins());
         }
     }
+
+    setFocus(): void {
+        var $canvas = $(this.viewer.canvas);
+
+        if (!$canvas.is(":focus"))
+            $canvas.focus();
+    }
 }
 export = SeadragonCenterPanel;

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -143,6 +143,10 @@ class BaseExtension implements IExtension {
             
             if (!this.useArrowKeysToNavigate()) {
                 $(document).keydown((e) => {
+                    //Prevent home, end, page up and page down from scrolling the window.
+                    if (e.keyCode === 33 || e.keyCode === 34 || e.keyCode === 35 || e.keyCode === 36)
+                        e.preventDefault();
+
                     var event: string = null;
 
                     if (e.keyCode === 37) event = BaseCommands.LEFT_ARROW;

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -140,6 +140,22 @@ class BaseExtension implements IExtension {
                     $.publish(event);
                 }
             });
+            
+            if (!this.useArrowKeysToNavigate()) {
+                $(document).keydown((e) => {
+                    var event: string = null;
+
+                    if (e.keyCode === 37) event = BaseCommands.LEFT_ARROW;
+                    if (e.keyCode === 38) event = BaseCommands.UP_ARROW;
+                    if (e.keyCode === 39) event = BaseCommands.RIGHT_ARROW;
+                    if (e.keyCode === 40) event = BaseCommands.DOWN_ARROW;
+
+                    if (event) {
+                        e.preventDefault();
+                        $.publish(event);
+                    }
+                });
+            }
 
             if (this.bootstrapper.params.isHomeDomain && Utils.Documents.IsInIFrame()) {
                 $(parent.document).on('fullscreenchange webkitfullscreenchange mozfullscreenchange MSFullscreenChange', (e) => {
@@ -149,6 +165,7 @@ class BaseExtension implements IExtension {
                         if (this.isOverlayActive()) {
                             $.publish(BaseCommands.ESCAPE);
                         }
+
                         $.publish(BaseCommands.ESCAPE);
                         $.publish(BaseCommands.RESIZE);
                     }
@@ -672,6 +689,10 @@ class BaseExtension implements IExtension {
 
     isRightPanelEnabled(): boolean{
         return  Utils.Bools.GetBool(this.provider.config.options.rightPanelEnabled, true);
+    }
+
+    useArrowKeysToNavigate(): boolean {
+        return Utils.Bools.GetBool(this.provider.config.options.useArrowKeysToNavigate, true);
     }
 
     // auth


### PR DESCRIPTION
Hi again!

I found the merge conflict and fixed it. This patch adds an option to allow using the arrow keys for scrolling in OSD instead of navigating between pages. It also fixes so that page up, page down, home and end doesn't scroll the browser window if UV has focus.

I've taken out the code for zooming, lets wait for OSD 2.1 on that one.