### PR TITLE
Add option in settings dialog to enable and disable the navigator

### DIFF
--- a/src/extensions/uv-seadragon-extension/ISettings.d.ts
+++ b/src/extensions/uv-seadragon-extension/ISettings.d.ts
@@ -1,4 +1,5 @@
 interface ISettings {
+    navigatorEnabled: boolean;
     pagingEnabled: boolean;
     preserveViewport: boolean;
 }

--- a/src/extensions/uv-seadragon-extension/SettingsDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/SettingsDialogue.ts
@@ -89,6 +89,12 @@ class SettingsDialogue extends BaseSettingsDialogue {
         super.open();
 
         var settings: ISettings = this.getSettings();
+        
+        if (settings.navigatorEnabled){
+            this.$navigatorEnabledCheckbox.prop("checked", true);
+        } else {
+            this.$navigatorEnabledCheckbox.removeAttr("checked");
+        }
 
         if (!this.provider.isPagingAvailable()){
             this.$pagingEnabled.hide();

--- a/src/extensions/uv-seadragon-extension/SettingsDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/SettingsDialogue.ts
@@ -2,6 +2,9 @@ import BaseSettingsDialogue = require("../../modules/uv-dialogues-module/Setting
 
 class SettingsDialogue extends BaseSettingsDialogue {
 
+    $navigatorEnabled: JQuery;
+    $navigatorEnabledCheckbox: JQuery;
+    $navigatorEnabledLabel: JQuery;
     $pagingEnabled: JQuery;
     $pagingEnabledCheckbox: JQuery;
     $pagingEnabledLabel: JQuery;
@@ -18,6 +21,15 @@ class SettingsDialogue extends BaseSettingsDialogue {
 
         super.create();
 
+        this.$navigatorEnabled = $('<div class="setting navigatorEnabled"></div>');
+        this.$scroll.append(this.$navigatorEnabled);
+
+        this.$navigatorEnabledCheckbox = $('<input id="navigatorEnabled" type="checkbox" />');
+        this.$navigatorEnabled.append(this.$navigatorEnabledCheckbox);
+
+        this.$navigatorEnabledLabel = $('<label for="navigatorEnabled">' + this.content.navigatorEnabled + '</label>');
+        this.$navigatorEnabled.append(this.$navigatorEnabledLabel);
+        
         this.$pagingEnabled = $('<div class="setting pagingEnabled"></div>');
         this.$scroll.append(this.$pagingEnabled);
 
@@ -35,6 +47,18 @@ class SettingsDialogue extends BaseSettingsDialogue {
 
         this.$preserveViewportLabel = $('<label for="preserveViewport">' + this.content.preserveViewport + '</label>');
         this.$preserveViewport.append(this.$preserveViewportLabel);
+
+        this.$navigatorEnabledCheckbox.change(() => {
+            var settings: ISettings = this.getSettings();
+
+            if(this.$navigatorEnabledCheckbox.is(":checked")) {
+                settings.navigatorEnabled = true;
+            } else {
+                settings.navigatorEnabled = false;
+            }
+
+            this.updateSettings(settings);
+        });
 
         this.$pagingEnabledCheckbox.change(() => {
             var settings: ISettings = this.getSettings();

--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -13,7 +13,7 @@
     "searchWithinEnabled": true,
     "theme": "uv-en-GB-theme",
     "useArrowKeysToNavigate": false,
-    "showNavigator": true
+    "navigatorEnabled": true
   },
   "modules":
   {

--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -12,7 +12,8 @@
     "rightPanelEnabled": true,
     "searchWithinEnabled": true,
     "theme": "uv-en-GB-theme",
-    "useArrowKeysToNavigate": false
+    "useArrowKeysToNavigate": false,
+    "showNavigator": true
   },
   "modules":
   {
@@ -86,7 +87,6 @@
         "navigatorPosition": "BOTTOM_RIGHT",
         "pageGap": 0.01,
         "showHomeControl": false,
-        "showNavigator": true,
         "trimAttributionCount": 150,
         "visibilityRatio": 0.5
       }

--- a/src/extensions/uv-seadragon-extension/l10n/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/en-GB.json
@@ -154,6 +154,7 @@
     "settingsDialogue": {
       "content": {
         "locale": "Locale",
+        "navigatorEnabled": "Mini View",
         "pagingEnabled": "Two Page View",
         "preserveViewport": "Preserve Zoom",
         "title": "Settings",

--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -76,7 +76,7 @@ class SeadragonCenterPanel extends CenterPanel {
             id: "viewer",
             ajaxWithCredentials: false,
             showNavigationControl: true,
-            showNavigator: this.config.options.showNavigator == null ? true : this.config.options.showNavigator,
+            showNavigator: this.provider.config.options.showNavigator == null ? true : this.provider.config.options.showNavigator,
             showRotationControl: true,
             showHomeControl: this.config.options.showHomeControl || false,
             showFullPageControl: false,

--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -160,6 +160,7 @@ class SeadragonCenterPanel extends CenterPanel {
         this.$rotateButton.addClass('rotate');
         
         this.$navigator = this.$viewer.find(".navigator");
+        this.setNavigatorVisible();
 
         // events
 
@@ -361,15 +362,7 @@ class SeadragonCenterPanel extends CenterPanel {
             }
         }
         
-        var navigatorEnabled = Utils.Bools.GetBool(this.provider.config.options.navigatorEnabled, true);
-        
-        this.viewer.navigator.setVisible(navigatorEnabled);
-        
-        if (navigatorEnabled)
-            this.$navigator.show();
-        else
-            this.$navigator.hide();
-        
+        this.setNavigatorVisible();
 
         this.isFirstLoad = false;
         this.overlaySearchResults();
@@ -555,6 +548,17 @@ class SeadragonCenterPanel extends CenterPanel {
 
         if (!$canvas.is(":focus"))
             $canvas.focus();
+    }
+    
+    setNavigatorVisible() {
+        var navigatorEnabled = Utils.Bools.GetBool(this.provider.config.options.navigatorEnabled, true);
+
+        this.viewer.navigator.setVisible(navigatorEnabled);
+        
+        if (navigatorEnabled)
+            this.$navigator.show();
+        else
+            this.$navigator.hide();
     }
 }
 export = SeadragonCenterPanel;

--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -33,6 +33,7 @@ class SeadragonCenterPanel extends CenterPanel {
     $viewer: JQuery;
     $zoomInButton: JQuery;
     $zoomOutButton: JQuery;
+    $navigator: JQuery;
 
     constructor($element: JQuery) {
         super($element);
@@ -76,7 +77,7 @@ class SeadragonCenterPanel extends CenterPanel {
             id: "viewer",
             ajaxWithCredentials: false,
             showNavigationControl: true,
-            showNavigator: this.provider.config.options.showNavigator == null ? true : this.provider.config.options.showNavigator,
+            showNavigator: true,
             showRotationControl: true,
             showHomeControl: this.config.options.showHomeControl || false,
             showFullPageControl: false,
@@ -157,6 +158,8 @@ class SeadragonCenterPanel extends CenterPanel {
         this.$rotateButton.attr('tabindex', 14);
         this.$rotateButton.prop('title', this.content.rotateRight);
         this.$rotateButton.addClass('rotate');
+        
+        this.$navigator = this.$viewer.find(".navigator");
 
         // events
 
@@ -357,6 +360,16 @@ class SeadragonCenterPanel extends CenterPanel {
                 this.disableNextButton();
             }
         }
+        
+        var navigatorEnabled = Utils.Bools.GetBool(this.provider.config.options.navigatorEnabled, true);
+        
+        this.viewer.navigator.setVisible(navigatorEnabled);
+        
+        if (navigatorEnabled)
+            this.$navigator.show();
+        else
+            this.$navigator.hide();
+        
 
         this.isFirstLoad = false;
         this.overlaySearchResults();


### PR DESCRIPTION
Hi!

This patch adds a new option to the settings dialog where you can enable or disable the navigator.

It also removes the option "showNavigator" in "seadragonCenterPanel" and adds a new option "navigatorEnabled" at the top instead.