### PR TITLE
Added option to save user settings to localStorage.

### DIFF
--- a/src/extensions/uv-seadragon-extension/ISettings.d.ts
+++ b/src/extensions/uv-seadragon-extension/ISettings.d.ts
@@ -1,5 +1,5 @@
 interface ISettings {
-    navigatorEnabled: boolean;
-    pagingEnabled: boolean;
-    preserveViewport: boolean;
+    navigatorEnabled?: boolean;
+    pagingEnabled?: boolean;
+    preserveViewport?: boolean;
 }

--- a/src/extensions/uv-seadragon-extension/SettingsDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/SettingsDialogue.ts
@@ -49,7 +49,7 @@ class SettingsDialogue extends BaseSettingsDialogue {
         this.$preserveViewport.append(this.$preserveViewportLabel);
 
         this.$navigatorEnabledCheckbox.change(() => {
-            var settings: ISettings = this.getSettings();
+            var settings: ISettings = {};
 
             if(this.$navigatorEnabledCheckbox.is(":checked")) {
                 settings.navigatorEnabled = true;
@@ -61,7 +61,7 @@ class SettingsDialogue extends BaseSettingsDialogue {
         });
 
         this.$pagingEnabledCheckbox.change(() => {
-            var settings: ISettings = this.getSettings();
+            var settings: ISettings = {};
 
             if(this.$pagingEnabledCheckbox.is(":checked")) {
                 settings.pagingEnabled = true;
@@ -73,7 +73,7 @@ class SettingsDialogue extends BaseSettingsDialogue {
         });
 
         this.$preserveViewportCheckbox.change(() => {
-            var settings: ISettings = this.getSettings();
+            var settings: ISettings = {};
 
             if(this.$preserveViewportCheckbox.is(":checked")) {
                 settings.preserveViewport = true;

--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -13,7 +13,8 @@
     "searchWithinEnabled": true,
     "theme": "uv-en-GB-theme",
     "useArrowKeysToNavigate": false,
-    "navigatorEnabled": true
+    "navigatorEnabled": true,
+    "saveUserSettings": false
   },
   "modules":
   {

--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -551,7 +551,7 @@ class SeadragonCenterPanel extends CenterPanel {
     }
     
     setNavigatorVisible() {
-        var navigatorEnabled = Utils.Bools.GetBool(this.provider.config.options.navigatorEnabled, true);
+        var navigatorEnabled = Utils.Bools.GetBool(this.provider.getSettings().navigatorEnabled, true);
 
         this.viewer.navigator.setVisible(navigatorEnabled);
         

--- a/src/modules/uv-shared-module/BaseProvider.ts
+++ b/src/modules/uv-shared-module/BaseProvider.ts
@@ -379,11 +379,27 @@ class BaseProvider implements IProvider{
     }
 
     getSettings(): ISettings {
+        if (Utils.Bools.GetBool(this.config.options.saveUserSettings, false)) {
+            var settings = Utils.Storage.get("settings", Utils.StorageType.local);
+            
+            if (settings)
+                return $.extend(this.config.options, settings.value);
+        }
+        
         return this.config.options;
     }
 
     updateSettings(settings: ISettings): void {
-        this.config.options = settings;
+        if (Utils.Bools.GetBool(this.config.options.saveUserSettings, false)) {
+            var storedSettings = Utils.Storage.get("settings", Utils.StorageType.local);
+            if (storedSettings)
+                settings = $.extend(storedSettings.value, settings);
+                
+            //store for ten years
+            Utils.Storage.set("settings", settings, 315360000, Utils.StorageType.local); 
+        }
+        
+        this.config.options = $.extend(this.config.options, settings);
     }
 
     sanitize(html: string): string {

--- a/src/modules/uv-shared-module/HeaderPanel.ts
+++ b/src/modules/uv-shared-module/HeaderPanel.ts
@@ -83,9 +83,7 @@ class HeaderPanel extends BaseView {
         this.updateLocaleToggle();
 
         this.$pagingToggleButton.on('click', () => {
-            var settings: ISettings = this.getSettings();
-            settings.pagingEnabled = !settings.pagingEnabled;
-            this.updateSettings(settings);
+            this.updateSettings({ pagingEnabled: !this.getSettings().pagingEnabled });
         });
 
         this.$localeToggleButton.on('click', () => {


### PR DESCRIPTION
Hi again!

I used your new code for saving to localStorage to implement saving of the options in the settings dialog. It saves the setting for navigator, paging and viewport, but not the language. I set it to save for 10 years, don't know if that's a good idea or not.