### PR TITLE
Added option to disable the expand full button.

### DIFF
--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -122,7 +122,8 @@
         "thumbsLoadRange": 15,
         "treeEnabled": true,
         "twoColThumbHeight": 150,
-        "twoColThumbWidth": 90
+        "twoColThumbWidth": 90,
+        "enableExpandFullButton": true
       }
     }
   }

--- a/src/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/modules/uv-shared-module/BaseExpandPanel.ts
@@ -35,6 +35,10 @@ class BaseExpandPanel extends BaseView {
         this.$expandFullButton = $('<a class="expandFullButton"></a>');
         this.$expandFullButton.prop('title', this.content.expandFull);
         this.$top.append(this.$expandFullButton);
+        
+        if (!Utils.Bools.GetBool(this.config.options.enableExpandFullButton, true)) {
+            this.$expandFullButton.hide();
+        } 
 
         this.$collapseButton = $('<div class="collapseButton"></div>');
         this.$collapseButton.prop('title', this.content.collapse);


### PR DESCRIPTION
This is an option to disable the expand full button in the left panel. We currently do not have thumbs enabled, which makes the full view kind of useless for us, and a bit confusing.