### PR TITLE
Hide unsupported fullscreen btn v2

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -13,21 +13,6 @@ var Utils;
     })();
     Utils.Bools = Bools;
 })(Utils || (Utils = {}));
-var Utils;
-(function (Utils) {
-    var Browser = (function () {
-        function Browser() {
-        }
-        Browser.SupportsFullscreen = function () {
-            var doc = document.documentElement;
-            var support = doc.requestFullscreen || doc.mozRequestFullScreen ||
-                doc.webkitRequestFullScreen || doc.msRequestFullscreen;
-            return support != undefined;
-        };
-        return Browser;
-    })();
-    Utils.Browser = Browser;
-})(Utils || (Utils = {}));
 // Copyright 2013 Basarat Ali Syed. All Rights Reserved.
 //
 // Licensed under MIT open source license http://opensource.org/licenses/MIT
@@ -2618,6 +2603,12 @@ var Utils;
             catch (e) {
                 return true;
             }
+        };
+        Documents.SupportsFullscreen = function () {
+            var doc = document.documentElement;
+            var support = doc.requestFullscreen || doc.mozRequestFullScreen ||
+                doc.webkitRequestFullScreen || doc.msRequestFullscreen;
+            return support != undefined;
         };
         return Documents;
     })();

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -13,6 +13,21 @@ var Utils;
     })();
     Utils.Bools = Bools;
 })(Utils || (Utils = {}));
+var Utils;
+(function (Utils) {
+    var Browser = (function () {
+        function Browser() {
+        }
+        Browser.SupportsFullscreen = function () {
+            var doc = document.documentElement;
+            var support = doc.requestFullscreen || doc.mozRequestFullScreen ||
+                doc.webkitRequestFullScreen || doc.msRequestFullscreen;
+            return support != undefined;
+        };
+        return Browser;
+    })();
+    Utils.Browser = Browser;
+})(Utils || (Utils = {}));
 // Copyright 2013 Basarat Ali Syed. All Rights Reserved.
 //
 // Licensed under MIT open source license http://opensource.org/licenses/MIT
@@ -2580,7 +2595,11 @@ var Utils;
         }
         Device.GetPixelRatio = function (ctx) {
             var dpr = window.devicePixelRatio || 1;
-            var bsr = ctx.webkitBackingStorePixelRatio || ctx.mozBackingStorePixelRatio || ctx.msBackingStorePixelRatio || ctx.oBackingStorePixelRatio || ctx.backingStorePixelRatio || 1;
+            var bsr = ctx.webkitBackingStorePixelRatio ||
+                ctx.mozBackingStorePixelRatio ||
+                ctx.msBackingStorePixelRatio ||
+                ctx.oBackingStorePixelRatio ||
+                ctx.backingStorePixelRatio || 1;
             return dpr / bsr;
         };
         return Device;

--- a/src/modules/uv-shared-module/FooterPanel.ts
+++ b/src/modules/uv-shared-module/FooterPanel.ts
@@ -95,7 +95,7 @@ class FooterPanel extends BaseView {
     }
 
     updateFullScreenButton(): void {
-        if (!Utils.Browser.SupportsFullscreen() || !Utils.Bools.GetBool(this.options.fullscreenEnabled, true)) {
+        if (!Utils.Documents.SupportsFullscreen() || !Utils.Bools.GetBool(this.options.fullscreenEnabled, true)) {
             this.$fullScreenBtn.hide();
         }
 

--- a/src/modules/uv-shared-module/FooterPanel.ts
+++ b/src/modules/uv-shared-module/FooterPanel.ts
@@ -95,7 +95,7 @@ class FooterPanel extends BaseView {
     }
 
     updateFullScreenButton(): void {
-        if (!Utils.Bools.GetBool(this.options.fullscreenEnabled, true)){
+        if (!Utils.Browser.SupportsFullscreen() || !Utils.Bools.GetBool(this.options.fullscreenEnabled, true)) {
             this.$fullScreenBtn.hide();
         }
 

--- a/src/typings/utils.d.ts
+++ b/src/typings/utils.d.ts
@@ -3,6 +3,11 @@ declare module Utils {
         static GetBool(val: any, defaultVal: boolean): boolean;
     }
 }
+declare module Utils {
+    class Browser {
+        static SupportsFullscreen(): boolean;
+    }
+}
 /**
  * @namespace Top level namespace for collections, a TypeScript data structure library.
  */

--- a/src/typings/utils.d.ts
+++ b/src/typings/utils.d.ts
@@ -3,11 +3,6 @@ declare module Utils {
         static GetBool(val: any, defaultVal: boolean): boolean;
     }
 }
-declare module Utils {
-    class Browser {
-        static SupportsFullscreen(): boolean;
-    }
-}
 /**
  * @namespace Top level namespace for collections, a TypeScript data structure library.
  */
@@ -1417,6 +1412,7 @@ declare module Utils {
 declare module Utils {
     class Documents {
         static IsInIFrame(): boolean;
+        static SupportsFullscreen(): boolean;
     }
 }
 declare module Utils {


### PR DESCRIPTION
Moved method to Documents class. Requires https://github.com/edsilv/utils/pull/2.