### PR TITLE
Image specific information in the right panel

### DIFF
--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -86,12 +86,15 @@
     {
       "options":
       {
+        "aggregateValues": "",
+        "canvasHeader": "About the image",
         "displayOrder": "",
         "exclude": "",
         "panelAnimationDuration": 250,
         "panelCollapsedWidth": 30,
         "panelExpandedWidth": 255,
         "panelOpen": false,
+        "manifestHeader": "About the book",
         "textLimit": 4,
         "textLimitType": "lines"
       }

--- a/src/extensions/uv-seadragon-extension/l10n/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/en-GB.json
@@ -113,7 +113,9 @@
         "logo": "Logo",
         "more": "more",
         "noData": "No data to display",
-        "title": "Information"
+        "title": "More Information",
+        "manifestHeader": "About the book",
+        "canvasHeader": "About the image"
       }
     },
     "pagingHeaderPanel": {

--- a/src/modules/uv-moreinforightpanel-module/css/styles.less
+++ b/src/modules/uv-moreinforightpanel-module/css/styles.less
@@ -29,6 +29,14 @@
             .items{
                 padding: 0 @padding-medium-horizontal (@padding-medium-vertical * 2) @padding-medium-horizontal;
 
+                .header {
+                    color: @brand-secondary;
+                    border-bottom: 1px solid @brand-secondary;
+                    font-size: @font-size-small;
+                    margin: @margin-large-vertical @margin-medium-horizontal 0 0;
+                    text-transform: uppercase;
+                }
+
                 .item {
                     padding: 0;
                     margin: 0 0 @margin-xlarge-vertical 0;


### PR DESCRIPTION
Hi!

This is the pull request for issue #188. This picks up any metadata values defined inside of canvases in the manifest. It works pretty much the same as when defining global metadata values, but it places the values in a new section at the bottom of the right panel. 

The text of the headers can both be configured and does not show if they are empty. A section does not show if there is no metadata for it in the manifest.

The configuration "aggregateValues" combines values from manifest level metadata and canvas level metadata. It takes a comma separated list that should match the value of the label in the metadata. If it finds a match in the canvas metadata, the matching values are aggregated.

For example we declare most of the source reference information only once in the manifest and then append the canvas specific data to the end. Our configuration looks like this:
"aggregateValues": "källhänvisning, source reference"

`"label": [
        {
          "@value": "Källhänvisning",
          "@language": "sv"
        },
        {
          "@value": "Source reference",
          "@language": "en-GB"
        }
      ]`
https://iiif.riksarkivet.se/arkis!C0000263/manifest

It the combines the values from the top of the manifest:
`"value": [
        {
          "@value": "Ervalla kyrkoarkiv, Husförhörslängder, SE/ULA/10219/A I/2 (1751-1763)",
          "@language": "sv"
        },
        {
          "@value": "Ervalla kyrkoarkiv, Husförhörslängder, SE/ULA/10219/A I/2 (1751-1763)",
          "@language": "en-GB"
        }
      ]`

with the values from the canvas:
`"value": [
                {
                  "@value": ", bildid: C0000263_00001",
                  "@language": "sv"
                },
                {
                  "@value": ", bildid: C0000263_00001",
                  "@language": "en-GB"
                }
              ]`

This is running in production on our end, I hope it can be useful for you too.