### PR TITLE
Exclude option for canvas metadata

### DIFF
--- a/src/extensions/uv-mediaelement-extension/config/en-GB.json
+++ b/src/extensions/uv-mediaelement-extension/config/en-GB.json
@@ -50,8 +50,9 @@
     {
       "options":
       {
+        "canvasExclude": "",
         "displayOrder": "",
-        "exclude": "",
+        "manifestExclude": "",
         "panelAnimationDuration": 250,
         "panelCollapsedWidth": 30,
         "panelExpandedWidth": 255

--- a/src/extensions/uv-pdf-extension/config/en-GB.json
+++ b/src/extensions/uv-pdf-extension/config/en-GB.json
@@ -44,8 +44,9 @@
     {
       "options":
       {
+        "canvasExclude": "",
         "displayOrder": "",
-        "exclude": "",
+        "manifestExclude": "",
         "panelAnimationDuration": 250,
         "panelCollapsedWidth": 30,
         "panelExpandedWidth": 255

--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -88,8 +88,9 @@
       {
         "aggregateValues": "",
         "canvasHeader": "About the image",
+        "canvasExclude": "",
         "displayOrder": "",
-        "exclude": "",
+        "manifestExclude": "",
         "panelAnimationDuration": 250,
         "panelCollapsedWidth": 30,
         "panelExpandedWidth": 255,

--- a/src/extensions/uv-virtex-extension/config/en-GB.json
+++ b/src/extensions/uv-virtex-extension/config/en-GB.json
@@ -43,8 +43,9 @@
     {
       "options":
       {
+        "canvasExclude": "",
         "displayOrder": "",
-        "exclude": "",
+        "manifestExclude": "",
         "panelAnimationDuration": 250,
         "panelCollapsedWidth": 30,
         "panelExpandedWidth": 255

--- a/src/modules/uv-moreinforightpanel-module/MoreInfoRightPanel.ts
+++ b/src/modules/uv-moreinforightpanel-module/MoreInfoRightPanel.ts
@@ -75,7 +75,7 @@ class MoreInfoRightPanel extends RightPanel {
             data = this.exclude(data, this.readConfig(this.options.manifestExclude));
         }
         
-        return this.flattenMetadataIntoArray(data);
+        return this.flatten(data);
     }
     
     getCanvasData(canvas: Manifesto.ICanvas) {
@@ -85,7 +85,7 @@ class MoreInfoRightPanel extends RightPanel {
             data = this.exclude(data, this.canvasExcludeConfig);
         }
         
-        return this.flattenMetadataIntoArray(data);
+        return this.flatten(data);
     }
     
     readConfig(config: string) {
@@ -166,11 +166,11 @@ class MoreInfoRightPanel extends RightPanel {
         return excluded;
     }
     
-    flattenMetadataIntoArray(renderData: IMetadataItem[]) {
+    flatten(data: IMetadataItem[]) {
         // flatten metadata into array.
         var flattened: IMetadataItem[] = [];
 
-        _.each(renderData, item => {
+        _.each(data, item => {
             if (_.isArray(item.value)){
                 flattened = flattened.concat(<IMetadataItem[]>item.value);
             } else {

--- a/src/modules/uv-shared-module/BaseProvider.ts
+++ b/src/modules/uv-shared-module/BaseProvider.ts
@@ -371,6 +371,22 @@ class BaseProvider implements IProvider{
 
         return result;
     }
+    
+    getCanvasMetadata(canvas: Manifesto.ICanvas): IMetadataItem[] {
+        var result: IMetadataItem[] = [];
+
+        var metadata = canvas.getMetadata();
+
+        if (metadata){
+            result.push(<IMetadataItem>{
+                label: "metadata",
+                value: metadata,
+                isRootLevel: true
+            });
+        }
+
+        return result;
+    }
 
     defaultToThumbsView(): boolean{
         switch (this.getManifestType().toString()){

--- a/src/modules/uv-shared-module/IProvider.ts
+++ b/src/modules/uv-shared-module/IProvider.ts
@@ -41,6 +41,7 @@ interface IProvider{
     getMetadata(): IMetadataItem[];
     getPagedIndices(index?: number): number[]; // todo: rename to something generic
     getRanges(): IRange[];
+    getCanvasMetadata(canvas: Manifesto.ICanvas): IMetadataItem[];
     getRangeByPath(path: string): Manifesto.IRange;
     getRangeCanvases(range: Manifesto.IRange): Manifesto.ICanvas[];
     getSeeAlso(): any;


### PR DESCRIPTION
This PR introduces a new option `canvasExclude` and renames `exclude` to `manifestExclude`. The only value that canvas can read for now is `metadata`, but I have tried to make it easy to add other values later on. I also made it so that the canvas title isn't shown if there is only values in canvas and not in the manifest.

Maybe all the code for manipulating the metadata should really be in some provider instead? It should be pretty easy to move parts of it now anyway.


