### PR TITLE
Fix bug: duplicate labels caused duplicate IDs, breaking downloads.

### DIFF
--- a/src/extensions/uv-seadragon-extension/DownloadDialogue.ts
+++ b/src/extensions/uv-seadragon-extension/DownloadDialogue.ts
@@ -219,12 +219,10 @@ class DownloadDialogue extends BaseDownloadDialogue {
             var rendering: Manifesto.IRendering = renderings[i];
             if (rendering) {
                 var label: string = rendering.getLabel();
-                var currentId: string;
+                var currentId: string = "dynamic_download_" + ++this.renderingUrlsCount;
                 if (label) {
-                    currentId = _.camelCase(label);
                     label += " ({0})";
                 } else {
-                    currentId = "dynamic_download_" + ++this.renderingUrlsCount;
                     label = defaultLabel;
                 }
                 label = String.format(label, this.simplifyMimeType(rendering.getFormat().toString()));


### PR DESCRIPTION
- Always use guaranteed-unique IDs for download radio buttons!
- Resolves #266.