### PR TITLE
Deep collection fix

### DIFF
--- a/src/Bootstrapper.ts
+++ b/src/Bootstrapper.ts
@@ -114,6 +114,16 @@ class Bootstrapper{
                             resolve();
                         }
 
+                        // Special case: we're trying to load the first manifest of the
+                        // collection, but the collection has no manifests but does have
+                        // subcollections. Thus, we should dive in until we find something
+                        // we can display!
+                        if (collection.getTotalManifests() == 0 && this.params.manifestIndex == 0 && collection.getTotalCollections() > 0) {
+                            that.params.collectionIndex = 0;
+                            that.params.manifestUri = collection.id;
+                            that.bootStrap(that.params);
+                        }
+
                         collection.getManifestByIndex(that.params.manifestIndex).then((manifest: Manifesto.IManifest) => {
                             resolve(manifest);
                         });


### PR DESCRIPTION
Without the code in this PR, there is a bug in the UV where clicking on a subcollection that contains only subcollections (not manifests) leads to a fatal error. You can reproduce this by loading the Villanova University Digital Library collection (http://digital.library.villanova.edu/Collection/vudl:3/IIIF) and clicking on the "Dime Novel and Popular Literature" collection in the Index.

This PR adds logic so that, if no manifests are found immediately within a subcollection, the bootstrapper will recurse deeper until it finds something.

This behavior is definitely better than a fatal error, but it does have some disadvantages:

  - If we have more than two levels of nested collections without manifests, some parts of the tree will be inaccessible because the UV will follow the tree downward until it finds a manifest, and it does not offer navigation options to get back to higher levels of the tree. Not sure how likely this is to happen in real life, but it does reveal a shortcoming of the current strategy of reloading the entire viewer to navigate through collections. It would probably provide a cleaner interface if we could dynamically load nodes into the existing tree instead of doing a full reload -- though of course I imagine that would complicate the code significantly.
  - The hash parameters do not seem to play well with deeply-nested trees. If you navigate into the dime novel collection (see example manifest above) and move between various collections and items, then refresh the page, you will either get an unexpected manifest or a fatal error. I suspect that the hash parameters are not taking tree depth into account at all, and so the index of the item accessed in the dime novel collection is being applied against the top-level collection after a refresh. I think if we load a whole new collection manifest, that needs to be reflected in the hash parameters somehow.

That second issue is a pretty big one, and we might want to come up with a solution before merging this.

Note that once we get all of this sorted out, I think we can also close #164.