### PR TITLE
Fixing XSS vulnerability in FooterPanel

### DIFF
--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -506,7 +506,7 @@ class FooterPanel extends BaseFooterPanel {
             }
 
             var lastCanvasOrderLabel = this.extension.helper.getLastCanvasLabel(true);
-            this.$pagePositionLabel.html(String.format(displaying, this.content.page, label, lastCanvasOrderLabel));
+            this.$pagePositionLabel.html(String.format(displaying, this.content.page, this.extension.sanitize(label), this.extension.sanitize(lastCanvasOrderLabel)));
         } else {
             this.$pagePositionLabel.html(String.format(displaying, this.content.image, index + 1, this.extension.helper.getTotalCanvases()));
         }


### PR DESCRIPTION
If there is a XSS injection in a label then it will be executed because of the unsafe nature of the html function.