### PR TITLE
Fix issue with clicking thumbnails

### DIFF
--- a/src/modules/uv-shared-module/ThumbsView.ts
+++ b/src/modules/uv-shared-module/ThumbsView.ts
@@ -127,7 +127,7 @@ class ThumbsView extends BaseView {
 
             that.lastThumbClickedIndex = data.index;
 
-            $.publish(BaseCommands.THUMB_SELECTED, [data]);
+            $.publish(BaseCommands.THUMB_SELECTED, [data.index]);
         });
 
         this.selectIndex(this.extension.helper.canvasIndex);


### PR DESCRIPTION
Clicking on thumbnails in the left panel produces various JS errors, because the full object is being passed instead of the index of the thumb. Line should be

$.publish(BaseCommands.THUMB_SELECTED, [data.index]);

instead of 

$.publish(BaseCommands.THUMB_SELECTED, [data]);