### PR TITLE
on click rotateButton event never fired in Firefox

### DIFF
--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -270,8 +270,8 @@ class SeadragonCenterPanel extends CenterPanel {
             $.publish(Commands.SEADRAGON_ANIMATION_FINISH, [viewer]);
         });
 
-        this.$rotateButton.on('click', () => {
-            $.publish(Commands.SEADRAGON_ROTATION, [this.viewer.viewport.getRotation()]);
+        this.viewer.addHandler('rotate', (args) => {
+            $.publish(Commands.SEADRAGON_ROTATION, [args.degrees]);
         });
 
         this.title = this.extension.helper.getLabel();


### PR DESCRIPTION
The onclick event for the rotateButton in Firefox is never fired.
It does in Chrome. Seems like this event is prevented from
propagating?

Consequences:
  * this.currentRotation is never changed to anything but the initial value
  * this.currentRotation is only set to something different than 0 when loaded from the url parameter
  * download buttons do not see the rotation (they use this.currentRotation)

This should work in both browsers. Don't know about Safari or IE.
