### PR TITLE
link collapsed attribution to attribution dialogue

### DIFF
--- a/src/extensions/uv-seadragon-extension/l10n/cy-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/cy-GB.json
@@ -170,7 +170,8 @@
         "previous": "blaenorol",
         "rotateRight": "Cylchdroi i'r dde",
         "zoomIn": "Closio",
-        "zoomOut": "Gwrthglosio"
+        "zoomOut": "Gwrthglosio",
+        "trimAttributionMore": "mwy"
       }
     },
     "searchFooterPanel": {

--- a/src/extensions/uv-seadragon-extension/l10n/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/l10n/en-GB.json
@@ -168,7 +168,8 @@
         "previous": "Previous",
         "rotateRight": "Rotate Right",
         "zoomIn": "Zoom In",
-        "zoomOut": "Zoom Out"
+        "zoomOut": "Zoom Out",
+        "trimAttributionMore": "more"
       }
     },
     "restrictedDialogue": {

--- a/src/modules/uv-shared-module/CenterPanel.ts
+++ b/src/modules/uv-shared-module/CenterPanel.ts
@@ -1,5 +1,6 @@
 import Shell = require("./Shell");
 import BaseView = require("./BaseView");
+import BaseCommands = require("./BaseCommands");
 
 class CenterPanel extends BaseView {
 
@@ -75,9 +76,20 @@ class CenterPanel extends BaseView {
 
         $attribution.targetBlank();
 
-        $attribution.toggleExpandText(this.options.trimAttributionCount, () => {
-            this.resize();
-        });
+        if ( $attribution.html().length > this.options.trimAttributionCount ){
+
+          var collapsedText = $attribution.html().substr(0, this.options.trimAttributionCount);
+          collapsedText = collapsedText.substr(0, Math.min(collapsedText.length, collapsedText.lastIndexOf(" ")));
+
+          var $toggleButton = $('<a href="#" class="toggle more">'+this.content.trimAttributionMore+'</a>');
+          $toggleButton.on('click',(e) => {
+            e.preventDefault();
+            $.publish(BaseCommands.SHOW_TERMS_OF_USE);
+          });
+          $attribution.html( collapsedText + "&hellip;&nbsp;" );
+          $attribution.append($toggleButton);
+
+        }
 
         //if (license){
         //    $license.append('<a href="' + license + '">' + license + '</a>');


### PR DESCRIPTION
when the number of characters in the attribution exceeds trimAttributionCount, 
the text is simply cut off, but there is no "more" appended (the text of that link is empty).

As there is already a dialogue where the full attribution can be shown, I think it's better
to link the "more" to this dialogue, instead of showing the full attribution in the centerPanel.