### PR TITLE
Solving problem with Preserve Zoom and images with different sizes

### DIFF
--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -703,7 +703,7 @@ class SeadragonCenterPanel extends CenterPanel {
         rect.width = bounds.width;
         rect.height = bounds.height;
 
-        this.viewer.viewport.fitBounds(rect, true);
+        this.viewer.viewport.fitBoundsWithConstraints(rect, true);
     }
 
     getBounds(): any {


### PR DESCRIPTION
Sometimes the images that gets the bounds of a previous image
with fitBounds is not visible.
