### PR TITLE
this.currentBounds not always a string

### DIFF
--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -877,7 +877,9 @@ class SeadragonCenterPanel extends CenterPanel {
         if (!this.isCreated) return;
 
         if (this.currentBounds) {
-            this.fitToBounds(Bounds.fromString(this.currentBounds))
+            this.fitToBounds(
+              typeof(this.currentBounds) == "string" ? Bounds.fromString(this.currentBounds) : this.currentBounds
+            );
         }
 
         this.$title.ellipsisFill(this.extension.sanitize(this.title));


### PR DESCRIPTION
this.currentBounds is sometimes a string, and sometimes an object of class Bounds.
The first thing happens when the width and height of the viewport are resized.