### PR TITLE
Fixed root path to be more generic

### DIFF
--- a/src/uv.html
+++ b/src/uv.html
@@ -33,7 +33,7 @@
             urlDataProvider = new UV.URLDataProvider();
 
             uv = createUV('#uv', {
-                root: '../uv',
+                root: '.',
                 iiifResourceUri: urlDataProvider.get('manifest'),
                 collectionIndex: Number(urlDataProvider.get('c', 0)),
                 manifestIndex: Number(urlDataProvider.get('m', 0)),


### PR DESCRIPTION
When root was set to ../uv, uv.html then would fail in any non-default directory. Using . makes this more portable.