### PR TITLE
keeps OSD prev/next controls enabled on focus or mousehover

### DIFF
--- a/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
+++ b/src/modules/uv-seadragoncenterpanel-module/SeadragonCenterPanel.ts
@@ -269,6 +269,13 @@ export class SeadragonCenterPanel extends CenterPanel {
         // when mouse move stopped
         this.$element.on('mousemove', () => {
             // if over element, hide controls.
+            // When over prev/next buttons keep controls enabled
+            if (this.$prevButton.ismouseover()) {
+                return;
+            }
+            if (this.$nextButton.ismouseover()) {
+                return;
+            }
             if (!this.$viewer.find('.navigator').ismouseover()) {
                 if (!this.controlsVisible) return;
                 this.controlsVisible = false;
@@ -376,6 +383,19 @@ export class SeadragonCenterPanel extends CenterPanel {
                     $.publish(Events.PREV);
                     break;
             }
+        });
+
+        // When Prev/Next buttons are focused, make sure the controls are enabled
+        this.$prevButton.on('focus', () => {
+            if (this.controlsVisible) return;
+            this.controlsVisible = true;
+            this.viewer.setControlsEnabled(true);
+        });
+        
+        this.$nextButton.on('focus', () => {
+            if (this.controlsVisible) return;
+            this.controlsVisible = true;
+            this.viewer.setControlsEnabled(true);
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/universalviewer/issues/13

![focus-hover](https://user-images.githubusercontent.com/1656824/28938593-6019f94c-7843-11e7-9666-7214f1c75f45.gif)
