### PR TITLE
wrap auth header in a <p>

### DIFF
--- a/src/modules/uv-shared-module/Auth1.ts
+++ b/src/modules/uv-shared-module/Auth1.ts
@@ -146,7 +146,7 @@ export class Auth1 {
         let errorMessage: string = "";
 
         if (service.getFailureHeader()) {
-            errorMessage += service.getFailureHeader() + '\n';
+            errorMessage += '<p>' + service.getFailureHeader() + '</p>';
         }
 
         if (service.getFailureDescription()) {


### PR DESCRIPTION
Without this, the `\n` is not respected in the rendered dialogue.

## Before
<img width="288" alt="screen shot 2017-08-03 at 4 48 49 pm" src="https://user-images.githubusercontent.com/1656824/28948623-be0ae8f4-786b-11e7-8f2a-e548f51f2c60.png">

## After
<img width="324" alt="screen shot 2017-08-03 at 4 47 40 pm" src="https://user-images.githubusercontent.com/1656824/28948620-bc2ed66c-786b-11e7-8824-05c9033a836b.png">