### PR TITLE
readonly attribute does not use a value

### DIFF
--- a/src/modules/uv-dialogues-module/ShareDialogue.ts
+++ b/src/modules/uv-dialogues-module/ShareDialogue.ts
@@ -93,7 +93,7 @@ export class ShareDialogue extends Dialogue {
         this.$shareLink = $('<a class="shareLink" onclick="return false;"></a>');
         this.$shareView.append(this.$shareLink);
 
-        this.$shareInput = $('<input class="shareInput" type="text" readonly="true" />');
+        this.$shareInput = $('<input class="shareInput" type="text" readonly />');
         this.$shareView.append(this.$shareInput);
 
         this.$shareFrame = $('<iframe class="shareFrame"></iframe>');
@@ -111,7 +111,7 @@ export class ShareDialogue extends Dialogue {
         // this.$image = $('<img class="share" />');
         // this.$embedView.append(this.$image);
 
-        this.$code = $('<input class="code" type="text" readonly="true" />');
+        this.$code = $('<input class="code" type="text" readonly />');
         this.$embedView.append(this.$code);
 
         this.$customSize = $('<div class="customSize"></div>');


### PR DESCRIPTION
From https://www.w3.org/TR/html401/interact/forms.html#adef-readonly

Running through: https://validator.w3.org
## Invalid
```html
<!DOCTYPE html>
<html>
<head><title>not valid</title></head>
<body>
<input readonly="true">
</body>
</html>
```

## Valid
```html
<!DOCTYPE html>
<html>
<head><title>valid</title></head>
<body>
<input readonly>
</body>
</html>
```