### PR TITLE
Add back button content in footer

### DIFF
--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -79,7 +79,11 @@ export class FooterPanel extends BaseFooterPanel {
             this.updateNextButton();
         });
 
-        this.$printButton = $('<button class="print imageBtn" title="' + this.content.print + '" tabindex="0"><i></i></button>');
+        this.$printButton = $(`
+          <button class="print btn imageBtn" title="${this.content.print}" tabindex="0">
+            <i class="uv-icon uv-icon-print" aria-hidden="true"></i>${this.content.print}
+          </button>
+        `);
         this.$options.prepend(this.$printButton);
 
         // search input.

--- a/src/modules/uv-shared-module/FooterPanel.ts
+++ b/src/modules/uv-shared-module/FooterPanel.ts
@@ -38,28 +38,60 @@ export class FooterPanel extends BaseView {
         this.$options = $('<div class="options"></div>');
         this.$element.append(this.$options);
 
-        this.$feedbackButton = $('<button class="feedback imageBtn" title="' + this.content.feedback + '" tabindex="0"><i></i></button>');
+        this.$feedbackButton = $(`
+          <button class="feedback btn imageBtn" title="${this.content.feedback}" tabindex="0">
+            <i class="uv-icon uv-icon-feedback" aria-hidden="true"></i>${this.content.feedback}
+          </button>
+        `);
         this.$options.prepend(this.$feedbackButton);
 
-        this.$openButton = $('<button class="open imageBtn" title="' + this.content.open + '" tabindex="0"><i></i></button>');
+        this.$openButton = $(`
+          <button class="open btn imageBtn" title="${this.content.open}" tabindex="0">
+            <i class="uv-icon-open" aria-hidden="true"></i>${this.content.open}
+          </button>
+        `);
         this.$options.prepend(this.$openButton);
 
-        this.$bookmarkButton = $('<button class="bookmark imageBtn" title="' + this.content.bookmark + '" tabindex="0"><i></i></button>');
+        this.$bookmarkButton = $(`
+          <button class="bookmark btn imageBtn" title="${this.content.bookmark}" tabindex="0">
+            <i class="uv-icon uv-icon-bookmark" aria-hidden="true"></i>${this.content.bookmark}
+          </button>
+        `);
         this.$options.prepend(this.$bookmarkButton);
 
-        this.$shareButton = $('<button class="share imageBtn" title="' + this.content.share + '" tabindex="0"><i></i></button>');
+        this.$shareButton = $(`
+          <button class="share btn imageBtn" title="${this.content.share}" tabindex="0">
+            <i class="uv-icon uv-icon-share" aria-hidden="true"></i>${this.content.share}
+          </button>
+        `);
         this.$options.append(this.$shareButton);
 
-        this.$embedButton = $('<button class="embed imageBtn" title="' + this.content.embed + '" tabindex="0"><i></i></button>');
+        this.$embedButton = $(`
+          <button class="embed btn imageBtn" title="${this.content.embed}" tabindex="0">
+            <i class="uv-icon uv-icon-embed" aria-hidden="true"></i>
+          </button>
+        `);
         this.$options.append(this.$embedButton);
 
-        this.$downloadButton = $('<button class="download imageBtn" title="' + this.content.download + '" tabindex="0"><i></i></button>');
+        this.$downloadButton = $(`
+          <button class="download btn imageBtn" title="${this.content.download}" tabindex="0">
+            <i class="uv-icon uv-icon-download" aria-hidden="true"></i>${this.content.download}
+          </button>
+        `);
         this.$options.prepend(this.$downloadButton);
 
-        this.$moreInfoButton = $('<button class="moreInfo imageBtn" title="' + this.content.moreInfo + '" tabindex="0"><i></i></button>');
+        this.$moreInfoButton = $(`
+          <button class="moreInfo btn imageBtn" title="${this.content.moreInfo}" tabindex="0">
+            <i class="uv-icon uv-icon-more-info" aria-hidden="true"></i>
+          </button>
+        `);
         this.$options.prepend(this.$moreInfoButton);
 
-        this.$fullScreenBtn = $('<button class="fullScreen imageBtn" title="' + this.content.fullScreen + '" tabindex="0"><i></i></button>');
+        this.$fullScreenBtn = $(`
+          <button class="fullScreen btn imageBtn" title="${this.content.fullScreen}" tabindex="0">
+            <i class="uv-icon uv-icon-fullscreen" aria-hidden="true"></i>
+          </button>
+        `);
         this.$options.append(this.$fullScreenBtn);
 
         this.$openButton.onPressed(() => {
@@ -158,9 +190,11 @@ export class FooterPanel extends BaseView {
 
         if (this.extension.isFullScreen()) {
             this.$fullScreenBtn.swapClass('fullScreen', 'exitFullscreen');
+            this.$fullScreenBtn.find('i').swapClass('uv-icon-fullscreen', 'uv-icon-exit-fullscreen');
             this.$fullScreenBtn.attr('title', this.content.exitFullScreen);
         } else {
             this.$fullScreenBtn.swapClass('exitFullscreen', 'fullScreen');
+            this.$fullScreenBtn.find('i').swapClass('uv-icon-exit-fullscreen', 'uv-icon-fullscreen');
             this.$fullScreenBtn.attr('title', this.content.fullScreen);
         }
     }

--- a/src/modules/uv-shared-module/css/footer-panel.less
+++ b/src/modules/uv-shared-module/css/footer-panel.less
@@ -7,159 +7,19 @@
         }
 
         .options {
-            height: 41px;
-
-            button {
-                float: left;
-                margin-top: 10px;
-                margin-right: 15px;
-
-                &.moreInfo {
-                    i {
-                        .icon-left('@{img-path}moreinfo.png', 21px, 35px);
-                    }
-                }
-
-                &.open {
-                    i {
-                        .icon-left('@{img-path}open.png', 21px, 35px);
-                    }
-                }
-
-                &.share {
-                    i {
-                        .icon-left('@{img-path}share.png', 21px, 35px);
-                    }
-                }
-
-                &.embed {
-                    i {
-                        .icon-left('@{img-path}embed.png', 21px, 35px);
-                    }
-                }
-
-                &.download {
-                    i {
-                        .icon-left('@{img-path}download.png', 21px, 30px);
-                    }
-                }
-
-                &.bookmark {
-                    i {
-                        .icon-left('@{img-path}bookmark.png', 21px, 30px);
-                    }
-                }
-
-                &.feedback {
-                    i {
-                        .icon-left('@{img-path}feedback.png', 21px, 30px);
-                    }
-                }
-
-                &.print {
-                    i {
-                        .icon-left('@{img-path}print.png', 21px, 30px);
-                    }
-                }
-
-                &.fullScreen {
-                    i {
-                        .icon-right('@{img-path}fullscreen.png', 21px, 30px);
-                    }
-                    min-width: 25px;
-                    float: right;
-                    margin-right: 0;
-                }
-
-                &.exitFullscreen {
-                    i {
-                        .icon-right('@{img-path}exit_fullscreen.png', 21px, 30px);
-                    }
-                    min-width: 25px;
-                    float: right;
-                    margin-right: 0;
-                }
+            height: 42px;
+            
+            .btn {
+              color: white;
+              font-size: 0;
+              
+              &.fullScreen,
+              &.exitFullscreen {
+                float: right;
+              }
             }
-
-            &.minimiseButtons {
-
-                a:first-child {
-                    margin-left: 10px;
-                }
-
-                a {
-
-                    &.moreInfo {
-                        .hide-text();
-                        width: 27px;
-                        padding: 0;
-                    }
-                    
-                    &.open {
-                        .hide-text();
-                        width: 27px;
-                        padding: 0;
-                    }
-
-                    &.download {
-                        .hide-text();
-                        width: 27px;
-                        padding: 0;
-                    }
-
-                    &.bookmark {
-                        .hide-text();
-                        width: 27px;
-                        padding: 0;
-                    }
-
-                    &.feedback {
-                        .hide-text();
-                        width: 27px;
-                        padding: 0;
-                    }
-                    
-                    &.print {
-                        .hide-text();
-                        width: 27px;
-                        padding: 0;
-                    }
-
-                    &.share {
-                        .hide-text();
-                        width: 27px;
-                        padding: 0;
-                    }
-
-                    &.embed {
-                        .hide-text();
-                        width: 27px;
-                        padding: 0;
-                    }
-
-                    &.fullScreen {
-                        .hide-text();
-                        width: 21px;
-                        padding: 0;
-                    }
-
-                    &.exitFullscreen {
-                        .hide-text();
-                        width: 21px;
-                        padding: 0;
-                    }
-
-                    &.normal {
-                        .hide-text();
-                        width: 21px;
-                        padding: 0;
-                    }
-                }
-            }
-
         }
     }
-
 }
 
 .uv.lightbox {

--- a/src/modules/uv-shared-module/css/icons.less
+++ b/src/modules/uv-shared-module/css/icons.less
@@ -1,0 +1,47 @@
+// Consolidated Icon Styles for UV
+// Icons that are images should be a size of 30px x 30px
+.uv {
+  .@{icon-prefix}, i {
+    display: inline-block;
+  }
+}
+
+.@{icon-prefix}-more-info {
+  .icon-btn-2('@{img-path}moreinfo.png');
+}
+
+.@{icon-prefix}-open {
+  .icon-btn-2('@{img-path}moreinfo.png');
+}
+
+.@{icon-prefix}-share {
+  .icon-btn-2('@{img-path}share.png');
+}
+
+.@{icon-prefix}-embed {
+  .icon-btn-2('@{img-path}embed.png');
+}
+
+.@{icon-prefix}-download {
+  .icon-btn-2('@{img-path}download.png');
+}
+
+.@{icon-prefix}-bookmark {
+  .icon-btn-2('@{img-path}bookmark.png');
+}
+
+.@{icon-prefix}-feedback {
+  .icon-btn-2('@{img-path}feedback.png');
+}
+
+.@{icon-prefix}-print {
+  .icon-btn-2('@{img-path}print.png');
+}
+
+.@{icon-prefix}-fullscreen {
+  .icon-btn-2('@{img-path}fullscreen.png');
+}
+
+.@{icon-prefix}-exit-fullscreen {
+  .icon-btn-2('@{img-path}exit_fullscreen.png');
+}

--- a/src/modules/uv-shared-module/css/mixins-extended.less
+++ b/src/modules/uv-shared-module/css/mixins-extended.less
@@ -22,6 +22,16 @@
     }
 }
 
+.icon-btn-2(@img) {
+  background-image: data-uri(@img);
+  background-repeat: no-repeat;
+  display: inline-block;
+  height: 30px;
+  vertical-align: middle;
+  width: 30px;
+  cursor: pointer;
+}
+
 .icon-btn(@img, @height) {
     background-image: data-uri(@img);
     background-repeat: no-repeat;

--- a/src/modules/uv-shared-module/css/styles.less
+++ b/src/modules/uv-shared-module/css/styles.less
@@ -1,6 +1,7 @@
 ﻿@import 'variables';
 @import 'mixins';
 @import 'mixins-extended';
+@import 'icons';
 @import 'scaffolding';
 @import 'buttons';
 @import 'range';
@@ -37,18 +38,13 @@
         .border-radius(0);
     }
 
+    // A button that should not have the browser default characteristics
     .imageBtn {
         background: 0 0;
         border: 0;
+        // border-radius: 0;
         cursor: pointer;
-        padding: 0px;
         .btn-focus();
-        i { 
-            background-repeat: no-repeat;
-            display: inline-block;
-            height: 100%;
-            width: 100%;
-        }
     }
 
     .action, a.action.black, input.action {

--- a/src/modules/uv-shared-module/css/variables.less
+++ b/src/modules/uv-shared-module/css/variables.less
@@ -212,3 +212,6 @@
 @scrollbar-width:               12px;
 @scrollbar-thumb-color:         @gray;
 @scrollbar-track-color:         none;
+
+// Icons
+@icon-prefix: uv-icon;


### PR DESCRIPTION
Can be turned on by setting font-size: 0.75rem to buttons

This PR also adds a consolidated way to define icons. Additional work could be done to consolidate the rest of the icon definitions. These buttons now are not offset or have the images padded, but instead are appropriately spaced.

## Default
<img width="960" alt="screen shot 2017-09-22 at 4 31 36 pm" src="https://user-images.githubusercontent.com/1656824/30767689-cfac63c0-9fb3-11e7-95d1-11daa8af1ed0.png">

## With font-size: 0.75rem;
<img width="965" alt="screen shot 2017-09-22 at 4 32 01 pm" src="https://user-images.githubusercontent.com/1656824/30767691-d0fbc5c2-9fb3-11e7-939c-a1c7857ff23b.png">

## Also fixes the focus selectors.
<img width="271" alt="screen shot 2017-09-22 at 4 32 18 pm" src="https://user-images.githubusercontent.com/1656824/30767693-d4774c3a-9fb3-11e7-8d22-f4ef4fd87838.png">

## Padding and spacing fixes
<img width="146" alt="screen shot 2017-09-22 at 4 33 24 pm" src="https://user-images.githubusercontent.com/1656824/30767697-e96f6da2-9fb3-11e7-99d4-2b3d505c721d.png">