### PR TITLE
move header icon buttons to consolidated approach, fixing spacing

### DIFF
--- a/src/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -70,10 +70,18 @@ export class PagingHeaderPanel extends HeaderPanel {
         this.$prevOptions = $('<div class="prevOptions"></div>');
         this.$centerOptions.append(this.$prevOptions);
 
-        this.$firstButton = $('<button class="imageBtn first" tabindex="0"><i></i></button>');
+        this.$firstButton = $(`
+          <button class="btn imageBtn first" tabindex="0">
+            <i class="uv-icon-first" aria-hidden="true"></i>
+          </button>
+        `);
         this.$prevOptions.append(this.$firstButton);
 
-        this.$prevButton = $('<button class="imageBtn prev" tabindex="0"><i></i></button>');
+        this.$prevButton = $(`
+          <button class="btn imageBtn prev" tabindex="0">
+            <i class="uv-icon-prev" aria-hidden="true"></i>
+          </button>
+        `);
         this.$prevOptions.append(this.$prevButton);
 
         this.$modeOptions = $('<div class="mode"></div>');
@@ -161,10 +169,18 @@ export class PagingHeaderPanel extends HeaderPanel {
         this.$nextOptions = $('<div class="nextOptions"></div>');
         this.$centerOptions.append(this.$nextOptions);
 
-        this.$nextButton = $('<button class="imageBtn next" tabindex="0"><i></i></button>');
+        this.$nextButton = $(`
+          <button class="btn imageBtn next" tabindex="0">
+            <i class="uv-icon-next" aria-hidden="true"></i>
+          </button>
+        `);
         this.$nextOptions.append(this.$nextButton);
 
-        this.$lastButton = $('<button class="imageBtn last" tabindex="0"><i></i></button>');
+        this.$lastButton = $(`
+          <button class="btn imageBtn last" tabindex="0">
+            <i class="uv-icon-last" aria-hidden="true"></i>
+          </button>
+        `);
         this.$nextOptions.append(this.$lastButton);
 
         if (this.isPageModeEnabled()) {
@@ -184,16 +200,27 @@ export class PagingHeaderPanel extends HeaderPanel {
             this.$pageModeLabel.text(this.content.page);
         }
 
-        this.$galleryButton = $('<button class="imageBtn gallery" title="' + this.content.gallery + '" tabindex="0"><i></i></button>');
+        this.$galleryButton = $(`
+          <button class="btn imageBtn gallery" title="${this.content.gallery}" tabindex="0">
+            <i class="uv-icon-gallery" aria-hidden="true"></i>
+          </button>
+        `);
         this.$rightOptions.prepend(this.$galleryButton);
 
         this.$pagingToggleButtons = $('<div class="pagingToggleButtons"></div>');
         this.$rightOptions.prepend(this.$pagingToggleButtons);
 
-        this.$oneUpButton = $('<button class="imageBtn one-up" title="' + this.content.oneUp + '" tabindex="0"><i></i></button>');
+        this.$oneUpButton = $(`
+          <button class="btn imageBtn one-up" title="${this.content.oneUp}" tabindex="0">
+            <i class="uv-icon-one-up" aria-hidden="true"></i>
+          </button>`);
         this.$pagingToggleButtons.append(this.$oneUpButton);
 
-        this.$twoUpButton = $('<button class="imageBtn two-up" title="' + this.content.twoUp + '" tabindex="0"><i></i></button>');
+        this.$twoUpButton = $(`
+          <button class="btn imageBtn two-up" title="${this.content.twoUp}" tabindex="0">
+            <i class="uv-icon-two-up" aria-hidden="true"></i>
+          </button>
+        `);
         this.$pagingToggleButtons.append(this.$twoUpButton);
 
         this.updatePagingToggle();

--- a/src/modules/uv-pagingheaderpanel-module/css/icons.less
+++ b/src/modules/uv-pagingheaderpanel-module/css/icons.less
@@ -1,0 +1,33 @@
+@header-img-path: '../../../modules/uv-pagingheaderpanel-module/img/';
+
+.@{icon-prefix}-first {
+  .icon-btn-2('@{header-img-path}first.png');
+}
+
+.@{icon-prefix}-prev {
+  .icon-btn-2('@{header-img-path}prev.png');
+}
+
+.@{icon-prefix}-next {
+  .icon-btn-2('@{header-img-path}next.png');
+}
+
+.@{icon-prefix}-last {
+  .icon-btn-2('@{header-img-path}last.png');
+}
+
+.@{icon-prefix}-go {
+  .icon-btn-2('@{header-img-path}go.png');
+}
+
+.@{icon-prefix}-one-up {
+  .icon-btn-2('@{header-img-path}one_up.png');
+}
+
+.@{icon-prefix}-two-up {
+  .icon-btn-2('@{header-img-path}two_up.png');
+}
+
+.@{icon-prefix}-gallery {
+  .icon-btn-2('@{header-img-path}grid.png');
+}

--- a/src/modules/uv-pagingheaderpanel-module/css/styles.less
+++ b/src/modules/uv-pagingheaderpanel-module/css/styles.less
@@ -1,71 +1,24 @@
-﻿
+@import 'icons';﻿
+
 .uv {
-
-    @img-path: '../../../modules/uv-pagingheaderpanel-module/img/';
-
-    // &.embedded {
-//        .headerPanel {
-//            background-image: data-uri('@{img-path}logo.png');
-//            background-repeat: no-repeat;
-//            background-position: 8px 8px;
-//        }
-    //}
 
     .headerPanel {
 
         color: @text-secondary-color;
 
-        button.imageBtn {
+        button.btn.imageBtn {
+          padding-left: 2px;
+          padding-right: 2px;
 
-            &.first {
-                i {
-                    background-color: @gray;
-                    background-image: data-uri('@{img-path}first.png');
-                    &:hover {
-                        background-color: @gray-dark;
-                    }
-                }
-                margin: 0 0 0 0;
-            }
-
-            &.prev {
-                i {
-                    background-color: @gray;
-                    background-image: data-uri('@{img-path}prev.png');
-                    &:hover {
-                        background-color: @gray-dark;
-                    }
-                }
-                margin: 0 0 0 5px;
-            }
-
-            &.next {
-                i {
-                    background-color: @gray;
-                    background-image: data-uri('@{img-path}next.png');
-                    &:hover {
-                        background-color: @gray-dark;
-                    }
-                }
-                margin: 0 5px 0 0;
-            }
-
+            &.first,
+            &.prev,
+            &.next,
             &.last {
                 i {
                     background-color: @gray;
-                    background-image: data-uri('@{img-path}last.png') ;
                     &:hover {
                         background-color: @gray-dark;
                     }
-                }
-                margin: 0 0 0 0;
-            }
-
-            &.go {
-                i {
-                    background: data-uri('@{img-path}go.png');
-                    line-height: 24px;
-                    width: 28px;
                 }
             }
 
@@ -97,12 +50,12 @@
 
             .mode {
                 float: left;
-                margin: 6px 0 0 0;
+                margin: 12px 0 0 0;
             }
 
             .search {
                 float: left;
-                margin: 0 0 0 5px;
+                margin: 6px 0 0 5px;
                 width: 113px;
 
                 .searchText {
@@ -192,20 +145,13 @@
         .rightOptions {
             .pagingToggleButtons {
                 float: left;
-                //margin: -1px 4px 0 0;
                 .one-up {
-                    i {
-                        background-image: data-uri('@{img-path}one_up.png');
-                    }
                     .opacity(1);
                     &.on {
                         .opacity(.75);
                     }
                 }
                 .two-up {
-                    i {
-                        background-image: data-uri('@{img-path}two_up.png');
-                    }
                     .opacity(1);
                     &.on {
                         .opacity(.75);
@@ -213,10 +159,6 @@
                 }
             }
             .gallery {
-                i {
-                    background-image: data-uri('@{img-path}grid.png');
-                }
-                margin-right: @margin-small-horizontal;
                 .opacity(1);
                 &.on {
                     .opacity(.75);

--- a/src/modules/uv-shared-module/HeaderPanel.ts
+++ b/src/modules/uv-shared-module/HeaderPanel.ts
@@ -50,7 +50,11 @@ export class HeaderPanel extends BaseView {
         this.$localeToggleButton = $('<a class="localeToggle" tabindex="0"></a>');
         this.$rightOptions.append(this.$localeToggleButton);
 
-        this.$settingsButton = $('<button class="imageBtn settings" tabindex="0"><i></i></button>');
+        this.$settingsButton = $(`
+          <button class="btn imageBtn settings" tabindex="0">
+            <i class="uv-icon-settings" aria-hidden="true"></i>
+          </button>
+        `);
         this.$settingsButton.attr('title', this.content.settings);
         this.$rightOptions.append(this.$settingsButton);
 

--- a/src/modules/uv-shared-module/css/header-panel.less
+++ b/src/modules/uv-shared-module/css/header-panel.less
@@ -21,13 +21,11 @@
             background-color: @panel-dark-bg;
 
             .centerOptions {
-                margin: 5px 0 0 0;
                 position: absolute;
             }
 
             .rightOptions {
                 float: right;
-                margin: @margin-small-vertical 0 0 0;
 
 //              .help {
 //                  margin-left: 1em;
@@ -40,9 +38,6 @@
 //              }
 
                 .settings {
-                    i {
-                        background: data-uri('@{img-path}settings.png');
-                    }
                     margin-right: 8px;
                 }
             }

--- a/src/modules/uv-shared-module/css/icons.less
+++ b/src/modules/uv-shared-module/css/icons.less
@@ -45,3 +45,7 @@
 .@{icon-prefix}-exit-fullscreen {
   .icon-btn-2('@{img-path}exit_fullscreen.png');
 }
+
+.@{icon-prefix}-settings {
+  .icon-btn-2('@{img-path}settings.png');
+}


### PR DESCRIPTION
A follow on to #503 . This PR moves the header panel icons/buttons to the same approach as the footer panel. The overall aim here is to simplify the styling needs for these buttons.

<img width="373" alt="screen shot 2017-09-23 at 12 28 48 pm" src="https://user-images.githubusercontent.com/1656824/30775064-28559620-a05b-11e7-9306-570772458b6a.png">
<img width="1015" alt="screen shot 2017-09-23 at 12 28 34 pm" src="https://user-images.githubusercontent.com/1656824/30775065-2855c9ba-a05b-11e7-82d9-18f4e40f6a42.png">
