### PR TITLE
Allow initialization with a search param w/o deep linking enabled.

### DIFF
--- a/src/extensions/uv-seadragon-extension/Extension.ts
+++ b/src/extensions/uv-seadragon-extension/Extension.ts
@@ -457,16 +457,12 @@ export class Extension extends BaseExtension implements ISeadragonExtension {
     }
 
     checkForSearchParam(): void {
-        // if a h value is in the hash params, do a search.
-        if (this.isDeepLinkingEnabled()) {
+        // if a highlight param is set, use it to search.
+        const highlight: string | null = (<ISeadragonExtensionData>this.data).highlight;
 
-            // if a highlight param is set, use it to search.
-            const highlight: string | null = (<ISeadragonExtensionData>this.data).highlight;
-
-            if (highlight) {
-                highlight.replace(/\+/g, " ").replace(/"/g, "");
-                $.publish(Events.SEARCH, [highlight]);
-            }
+        if (highlight) {
+            highlight.replace(/\+/g, " ").replace(/"/g, "");
+            $.publish(Events.SEARCH, [highlight]);
         }
     }
 


### PR DESCRIPTION
The search param is no longer being pulled from a hash param and is
instead sent in when UV is initialized. This can work w/o deep linking.