### PR TITLE
Do not change the metric, if it has not changed

### DIFF
--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -768,7 +768,7 @@ export class BaseExtension implements IExtension {
             }
 
             if (!metricChanged) {
-                this.metric = MetricType.NONE;
+                // If the metric hasn't changed, no need to set it to anything.
             }
         }, 1);
     }


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/universalviewer/issues/49

We experienced consistency issues where if a resize event occurred on the page, the `MetricType` would be set to `NONE`. This often caused the navigator to be removed from the osd window.

This idea of a `NONE` metric was introduce here: https://github.com/UniversalViewer/universalviewer/commit/28b5b21402a04f9f242594b3eab326a9faa4dbb9 but its unclear to me what the intent was of setting this to `NONE` on line 771. We are open to other approaches to solving this bug, but in pairing with @aeschylus this seemed to be the best approach we could come up with.