### PR TITLE
allow for multi word autocomplete searches

### DIFF
--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -102,6 +102,7 @@
     },
     "footerPanel": {
       "options":{
+        "autocompleteAllowWords": false,
         "bookmarkEnabled": false,
         "downloadEnabled": true,
         "embedEnabled": false,
@@ -155,6 +156,7 @@
     "pagingHeaderPanel": {
       "options": {
         "autoCompleteBoxEnabled": true,
+        "autocompleteAllowWords": false,
         "galleryButtonEnabled": true,
         "imageSelectionBoxEnabled": false,
         "pageModeEnabled": false,

--- a/src/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -140,7 +140,8 @@ export class PagingHeaderPanel extends HeaderPanel {
                     this.search(terms);
                 },
                 300,
-                0
+                0,
+                Utils.Bools.getBool(this.options.autocompleteAllowWords, false)
             );
         } else if (Utils.Bools.getBool(this.options.imageSelectionBoxEnabled, true)) {
             this.$selectionBoxOptions = $('<div class="image-selectionbox-options"></div>');

--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -226,7 +226,7 @@ export class FooterPanel extends BaseFooterPanel {
                 (terms: string) => {
                     this.search(terms);
                 },
-                300, 2, true
+                300, 2, true, Utils.Bools.getBool(this.options.autocompleteAllowWords, false)
             );
 
         } else {

--- a/src/modules/uv-shared-module/AutoComplete.ts
+++ b/src/modules/uv-shared-module/AutoComplete.ts
@@ -10,6 +10,7 @@ export class AutoComplete {
     private _onSelect: (terms: string) => void;
     private _parseResultsFunc: (results: string[]) => string[];
     private _positionAbove: boolean;
+    private _allowWords: boolean;
 
 	private _$searchResultsList: JQuery;
 	private _$searchResultTemplate: JQuery;
@@ -24,7 +25,8 @@ export class AutoComplete {
                 onSelect: (terms: string) => void,
                 delay: number = 300,
                 minChars: number = 2,
-                positionAbove: boolean = false) {
+                positionAbove: boolean = false,
+                allowWords: boolean = false) {
 
         this._$element = element;
         this._autoCompleteFunc = autoCompleteFunc;
@@ -33,6 +35,7 @@ export class AutoComplete {
         this._onSelect = onSelect;
         this._parseResultsFunc = parseResultsFunc;
         this._positionAbove = positionAbove;
+        this._allowWords = allowWords;
 
         // create ui.
         this._$searchResultsList = $('<ul class="autocomplete"></ul>');
@@ -120,7 +123,7 @@ export class AutoComplete {
 
                     // if there are more than x chars
                     // update the autocomplete list.
-                    if (val && val.length > that._minChars) {
+                    if (val && val.length > that._minChars && that._searchForWords(val)) {
                         that._search(val);
                     } else {
                         // otherwise, hide the autocomplete list.
@@ -142,6 +145,14 @@ export class AutoComplete {
         });
 
         this._hideResults();
+    }
+
+    private _searchForWords(search: string): boolean {
+      if (this._allowWords || !search.includes(' ')) {
+        return true;
+      } else {
+        return false;
+      }
     }
 
     // private _isNavigationKeyDown(e: KeyboardEvent): boolean {

--- a/src/modules/uv-shared-module/AutoComplete.ts
+++ b/src/modules/uv-shared-module/AutoComplete.ts
@@ -118,9 +118,9 @@ export class AutoComplete {
 
                     const val = that._getTerms();
 
-                    // if there are more than x chars and no spaces
+                    // if there are more than x chars
                     // update the autocomplete list.
-                    if (val && val.length > that._minChars && !val.includes(' ')) {
+                    if (val && val.length > that._minChars) {
                         that._search(val);
                     } else {
                         // otherwise, hide the autocomplete list.

--- a/src/modules/uv-shared-module/AutoComplete.ts
+++ b/src/modules/uv-shared-module/AutoComplete.ts
@@ -14,10 +14,6 @@ export class AutoComplete {
 
 	private _$searchResultsList: JQuery;
 	private _$searchResultTemplate: JQuery;
- 
-    //private _navigationKeyDownCodes: number[] = [KeyCodes.KeyDown.Backspace, KeyCodes.KeyDown.Spacebar, KeyCodes.KeyDown.Tab, KeyCodes.KeyDown.LeftArrow, KeyCodes.KeyDown.RightArrow, KeyCodes.KeyDown.Delete];
-    //private _validKeyPressCodes: number[] = [KeyCodes.KeyPress.GraveAccent, KeyCodes.KeyPress.DoubleQuote];
-    //private _lastKeyDownWasNavigation: boolean = false;
 
     constructor(element: JQuery,
                 autoCompleteFunc: (terms: string, cb: (results: string[]) => void) => void,
@@ -79,19 +75,6 @@ export class AutoComplete {
                 if(originalEvent.stopPropagation) originalEvent.stopPropagation();
             }
         });
-
-        // prevent invalid characters being entered
-        // this._$element.on("keypress", function(e: JQueryEventObject) {
-
-        //     const isValidKeyPress: boolean = that._isValidKeyPress(<KeyboardEvent>e.originalEvent);
-
-        //     if (!(that._lastKeyDownWasNavigation || isValidKeyPress)) {
-        //         e.preventDefault();
-        //         return false;
-        //     }
-
-        //     return true;
-        // });
 
         // auto complete
         this._$element.on("keyup", function(e) {
@@ -155,18 +138,6 @@ export class AutoComplete {
       }
     }
 
-    // private _isNavigationKeyDown(e: KeyboardEvent): boolean {
-    //     const isNavigationKeyDown: boolean = this._navigationKeyDownCodes.includes(Utils.Keyboard.getCharCode(e));
-    //     return isNavigationKeyDown;
-    // }
-
-    // private _isValidKeyPress(e: KeyboardEvent): boolean {
-    //     const charCode: number = Utils.Keyboard.getCharCode(e);
-    //     const key: string = String.fromCharCode(charCode);
-    //     const isValid: boolean = key.isAlphanumeric() || this._validKeyPressCodes.includes(charCode);
-    //     return isValid;
-    // }
-
     private _getTerms(): string {
         return this._$element.val().trim();
     }
@@ -197,7 +168,6 @@ export class AutoComplete {
 
         $selectedItem.addClass('selected');
 
-        //var top = selectedItem.offset().top;
         const top = $selectedItem.outerHeight(true) * this._selectedResultIndex;
 
         this._$searchResultsList.scrollTop(top);


### PR DESCRIPTION
This allows for adopters to use a multi word search for autocomplete. ~~If desired I can push this into a configuration or setting instead.~~

35b97366f1c904da310454b74a855c626af68711 moves this into a configuration option that can be used by a module to implement individually (`FooterPanel` or `PagingHeaderPanel`). The default option is the previous behavior.