### PR TITLE
Adds a configurable way to set thumbnail caching

### DIFF
--- a/__tests__/configuration_options.js
+++ b/__tests__/configuration_options.js
@@ -1,0 +1,32 @@
+describe('Configuration options', () => {
+  describe('thumb cache invaldiation', () => {
+    beforeEach(async () => {
+      await page.goto('http://localhost:4444/examples');
+      await page.waitForSelector('#thumb0');
+    });
+    it('when set to false does not provide timestamp', async () => {
+      await page.evaluate(() => uv.set(
+        { config: { modules: { contentLeftPanel: { options: { thumbsCacheInvalidation: { enabled: false }}}}}}
+      ));
+      await page.waitForSelector('#thumb0');
+      const imageSrc = await page.$eval('#thumb0 img', e => e.src);
+      expect(imageSrc).toEqual( 
+        expect.stringMatching(
+          'https://dlcs.io/iiif-img/wellcome/1/ff2085d5-a9c7-412e-9dbe-dda87712228d/full/90,/0/default.jpg'
+        )
+      );
+    });
+    it('has a configurable parameter type', async () => {
+      await page.evaluate(() => uv.set(
+        { config: { modules: { contentLeftPanel: { options: { thumbsCacheInvalidation: { paramType: '#' }}}}}}
+      ));
+      await page.waitForSelector('#thumb0');
+      const imageSrc = await page.$eval('#thumb0 img', e => e.src);
+      expect(imageSrc).toEqual( 
+        expect.stringContaining(
+          'https://dlcs.io/iiif-img/wellcome/1/ff2085d5-a9c7-412e-9dbe-dda87712228d/full/90,/0/default.jpg#t='
+        )
+      );
+    });
+  });
+});

--- a/src/UVComponent.ts
+++ b/src/UVComponent.ts
@@ -327,7 +327,7 @@ export default class UVComponent extends _Components.BaseComponent implements IU
         if (configExtension) {
             // save a reference to the config extension uri.
             config.uri = data.configUri;
-            $.extend(true, config, configExtension);
+            $.extend(true, config, configExtension, data.config);
         }
 
         cb(config);

--- a/src/extensions/uv-seadragon-extension/config/en-GB.json
+++ b/src/extensions/uv-seadragon-extension/config/en-GB.json
@@ -80,6 +80,10 @@
         "panelExpandedWidth": 255,
         "panelOpen": true,
         "tabOrder": "",
+        "thumbsCacheInvalidation": {
+          "enabled": true,
+          "paramType": "?"
+        },
         "thumbsEnabled": true,
         "thumbsExtraHeight": 8,
         "thumbsImageFadeInDuration": 300,

--- a/src/modules/uv-shared-module/ThumbsView.ts
+++ b/src/modules/uv-shared-module/ThumbsView.ts
@@ -171,9 +171,8 @@ export class ThumbsView extends BaseView {
             end: (thumbRangeMid < (this.thumbs.length - 1) - thumbLoadRange) ? thumbRangeMid + thumbLoadRange : this.thumbs.length - 1
         };
 
-        //console.log('start: ' + thumbRange.start + ' end: ' + thumbRange.end);
-
         const fadeDuration: number = this.options.thumbsImageFadeInDuration;
+        const that = this;
 
         for (let i = thumbRange.start; i <= thumbRange.end; i++) {
 
@@ -188,8 +187,9 @@ export class ThumbsView extends BaseView {
                     $wrap.removeClass('loadingFailed');
                     $wrap.addClass('loading');
                     let src: string = $thumb.attr('data-src');
-                    src += '?t=' + Utils.Dates.getTimeStamp();
-                    //console.log(i, src);
+                    if (that.config.options.thumbsCacheInvalidation.enabled) {
+                      src += `${that.config.options.thumbsCacheInvalidation.paramType}t=${Utils.Dates.getTimeStamp()}`;
+                    }
                     const $img: JQuery = $('<img src="' + src + '" alt=""/>');
                     // fade in on load.
                     $img.hide().load(function () {


### PR DESCRIPTION
This supports both browser and server side thumbnail caching
configurations.

Fixes #537 
Fixes #431 

This PR also fixes an issue (in cffcd4c) where when using `UVComponent#set`, the data you are setting it to was actually not merged back into the config.

~~I'm still looking into a way to test this. Likely will need to make changes to how `/examples` works to do so.~~

Updated with integration tests. Testing `UVComponent` by itself will likely require some more work to look into handle that.

![uvnotimestamp](https://user-images.githubusercontent.com/1656824/38645362-084c1096-3da1-11e8-8cdd-b111c6a52edb.gif)
