### PR TITLE
Fixed default audio width and height

### DIFF
--- a/src/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
+++ b/src/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
@@ -136,8 +136,8 @@ export class MediaElementCenterPanel extends CenterPanel {
 
                 this.player = new MediaElementPlayer($('audio')[0], {
                     poster: poster,
-                    defaultAudioWidth: that.mediaWidth,
-                    defaultAudioHeight: that.mediaHeight,
+                    defaultAudioWidth: 'auto',
+                    defaultAudioHeight: 'auto',
                     showPosterWhenPaused: true,
                     showPosterWhenEnded: true,
                     success: function(mediaElement: any, originalNode: any) {


### PR DESCRIPTION
Without this change the initial height gets stuck and does not adjust to resizing the browser