### PR TITLE
Update thumbs-view.less

### DIFF
--- a/src/modules/uv-shared-module/css/thumbs-view.less
+++ b/src/modules/uv-shared-module/css/thumbs-view.less
@@ -181,7 +181,7 @@
                     &.right-to-left {
                         .thumb {
                             &.first {
-                                float: left;
+                                //float: left;
                             }
                             float: right;
                         }


### PR DESCRIPTION
fixed the bug which the first thumbnail is placed to the left when the viewingDirection is set as "right-to-left"