### PR TITLE
Encode search terms in URI request

### DIFF
--- a/src/extensions/uv-seadragon-extension/Extension.ts
+++ b/src/extensions/uv-seadragon-extension/Extension.ts
@@ -997,7 +997,7 @@ export class Extension extends BaseExtension implements ISeadragonExtension {
 
         if (!searchUri) return;
 
-        searchUri = Utils.Strings.format(searchUri, terms);
+        searchUri = Utils.Strings.format(searchUri, encodeURIComponent(terms));
 
         this.getSearchResults(searchUri, terms, this.annotations, (annotations: AnnotationGroup[]) => {
 


### PR DESCRIPTION
We use Solr as our backend for full-text searching, and users are instructed on how to use + to require words. But the plus (and other special characters) were not being encoded in the search request, so they were not functioning properly.

This change simply encodes the search terms in the URI.