### PR TITLE
Share manifest URIs for cases where a IIIF Collection is being viewed

### DIFF
--- a/src/modules/uv-dialogues-module/ShareDialogue.ts
+++ b/src/modules/uv-dialogues-module/ShareDialogue.ts
@@ -34,6 +34,7 @@ export class ShareDialogue extends Dialogue {
     maxHeight: number = this.maxWidth * this.aspectRatio;
     minWidth: number = 200;
     minHeight: number = this.minWidth * this.aspectRatio;
+    shareManifests: boolean = false;
 
     constructor($element: JQuery) {
         super($element);
@@ -47,6 +48,7 @@ export class ShareDialogue extends Dialogue {
 
         this.openCommand = BaseEvents.SHOW_SHARE_DIALOGUE;
         this.closeCommand = BaseEvents.HIDE_SHARE_DIALOGUE;
+        this.shareManifests = this.options.shareManifests || false;
 
         $.subscribe(this.openCommand, (e: any, $triggerButton: JQuery) => {
             this.open($triggerButton);
@@ -136,7 +138,7 @@ export class ShareDialogue extends Dialogue {
         this.$heightInput = $('<input class="height" type="text" maxlength="10" aria-label="' + this.content.height + '"/>');
         this.$customSize.append(this.$heightInput);
 
-        const iiifUrl: string = this.extension.getIIIFShareUrl();
+        const iiifUrl: string = this.extension.getIIIFShareUrl(this.shareManifests);
 
         this.$iiifButton = $('<a class="imageBtn iiif" href="' + iiifUrl + '" title="' + this.content.iiif + '" target="_blank"></a>');
         this.$footer.append(this.$iiifButton);

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -890,7 +890,7 @@ export class BaseExtension implements IExtension {
     }   
 
     getIIIFShareUrl(): string {
-        return this.helper.iiifResourceUri + "?manifest=" + this.helper.iiifResourceUri;
+        return `${this.helper.manifest.id}?manifest=${this.helper.manifest.id}`;
     }
 
     addTimestamp(uri: string): string {

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -889,8 +889,12 @@ export class BaseExtension implements IExtension {
         return null;
     }   
 
-    getIIIFShareUrl(): string {
-        return `${this.helper.manifest.id}?manifest=${this.helper.manifest.id}`;
+    getIIIFShareUrl(shareManifests: boolean = false): string {
+        if (shareManifests) {
+          return `${this.helper.manifest.id}?manifest=${this.helper.manifest.id}`;
+        } else {
+          return this.helper.iiifResourceUri + "?manifest=" + this.helper.iiifResourceUri;
+        }
     }
 
     addTimestamp(uri: string): string {

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -890,11 +890,8 @@ export class BaseExtension implements IExtension {
     }   
 
     getIIIFShareUrl(shareManifests: boolean = false): string {
-        if (shareManifests) {
-          return `${this.helper.manifest.id}?manifest=${this.helper.manifest.id}`;
-        } else {
-          return this.helper.iiifResourceUri + "?manifest=" + this.helper.iiifResourceUri;
-        }
+        var manifestUri: string = shareManifests ? this.helper.manifest.id : this.helper.iiifResourceUri;
+        return `${manifestUri}?manifest=${manifestUri}`;
     }
 
     addTimestamp(uri: string): string {

--- a/src/modules/uv-shared-module/IExtension.ts
+++ b/src/modules/uv-shared-module/IExtension.ts
@@ -23,7 +23,7 @@ export interface IExtension {
     getDependencies(callback: (deps: any) => void): any;
     getDomain(): string;
     getExternalResources(resources?: Manifesto.IExternalResource[]): Promise<Manifesto.IExternalResourceData[]>;
-    getIIIFShareUrl(): string;
+    getIIIFShareUrl(shareManifests?: boolean): string;
     getLocale(): string;
     getMediaFormats(canvas: Manifesto.ICanvas): Manifesto.IAnnotationBody[];
     getPagedIndices(canvasIndex?: number): number[];


### PR DESCRIPTION
Currently, at the Princeton University Library, we have cases where we use the Universal Viewer to access `sc:Collections` with multiple volumes as manifests.  Please see the following example:

http://universalviewer.io/examples/#?c=&m=&s=&cv=&manifest=https%3A%2F%2Ffiggy.princeton.edu%2Fconcern%2Fscanned_resources%2Fabcbea26-6600-4445-be9f-bf0ac0ba965a%2Fmanifest&xywh=-1549%2C-787%2C5665%2C5114

When users attempt to use the drag-and-drop icon within the share dialogue to integrate with an application such as [Mirador](http://projectmirador.org/demo/), these can break.  In order to avoid these types of compatibility issues, we have modified the URL generation for this in order to just provide the manifest for the canvas selected for viewing.