### PR TITLE
Setting z-index for overlays (download, share, etc.)

### DIFF
--- a/src/modules/uv-mediaelementcenterpanel-module/css/overrides.less
+++ b/src/modules/uv-mediaelementcenterpanel-module/css/overrides.less
@@ -28,3 +28,7 @@
 .uv .centerPanel .content .attribution {
     z-index: 100;
 }
+
+.uv .overlays {
+    z-index: 101 !important;
+}


### PR DESCRIPTION
So that they aren't hidden by the Attribution statement