### PR TITLE
Provides the posterImageExpanded argument to the AVCenterPanel constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@edsilv/key-codes": "0.0.9",
     "@edsilv/utils": "0.2.6",
     "@iiif/base-component": "1.1.4",
-    "@iiif/iiif-av-component": "jrgriffiniii/iiif-av-component#jrgriffiniii-postercanvas-expanded",
+    "@iiif/iiif-av-component": "0.0.93",
     "@iiif/iiif-gallery-component": "1.1.13",
     "@iiif/iiif-metadata-component": "1.1.13",
     "@iiif/iiif-tree-component": "1.1.16",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@edsilv/key-codes": "0.0.9",
     "@edsilv/utils": "0.2.6",
     "@iiif/base-component": "1.1.4",
-    "@iiif/iiif-av-component": "0.0.87",
+    "@iiif/iiif-av-component": "jrgriffiniii/iiif-av-component#jrgriffiniii-postercanvas-expanded",
     "@iiif/iiif-gallery-component": "1.1.13",
     "@iiif/iiif-metadata-component": "1.1.13",
     "@iiif/iiif-tree-component": "1.1.16",

--- a/src/modules/uv-avcenterpanel-module/AVCenterPanel.ts
+++ b/src/modules/uv-avcenterpanel-module/AVCenterPanel.ts
@@ -105,7 +105,8 @@ export class AVCenterPanel extends CenterPanel {
         this.$content.prepend(this.$avcomponent);
 
         this.avcomponent = new IIIFComponents.AVComponent({
-            target: <HTMLElement>this.$avcomponent[0]
+            target: <HTMLElement>this.$avcomponent[0],
+            posterImageExpanded: this.options.posterImageExpanded
         });
 
         this.avcomponent.on('mediaready', () => {


### PR DESCRIPTION
Modifies the arguments passed to the AVComponent constructor in order to support the changes introduced into `@iiif/iiif-av-component` with https://github.com/IIIF-Commons/iiif-av-component/pull/35.

I can issue this as a full pull request following a new patch or minor release for https://www.npmjs.com/package/@iiif/iiif-av-component