### PR TITLE
Improve XHTML compatibility

### DIFF
--- a/src/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -138,7 +138,7 @@ export class ContentLeftPanel extends LeftPanel {
         this.$sortButtonGroup = $('<div class="btn-group"></div>');
         this.$treeViewOptions.append(this.$sortButtonGroup);
 
-        this.$sortByDateButton = $('<button class="btn tabindex="0"">' + this.content.date + '</button>');
+        this.$sortByDateButton = $('<button class="btn" tabindex="0">' + this.content.date + '</button>');
         this.$sortButtonGroup.append(this.$sortByDateButton);
 
         this.$sortByVolumeButton = $('<button class="btn" tabindex="0">' + this.content.volume + '</button>');

--- a/src/modules/uv-dialogues-module/ShareDialogue.ts
+++ b/src/modules/uv-dialogues-module/ShareDialogue.ts
@@ -93,7 +93,7 @@ export class ShareDialogue extends Dialogue {
         this.$shareLink = $('<a class="shareLink" onclick="return false;"></a>');
         this.$shareView.append(this.$shareLink);
 
-        this.$shareInput = $(`<input class="shareInput" type="text" readonly aria-label="${this.content.shareUrl}"/>`);
+        this.$shareInput = $(`<input class="shareInput" type="text" readonly="readonly" aria-label="${this.content.shareUrl}"/>`);
         this.$shareView.append(this.$shareInput);
 
         this.$shareFrame = $('<iframe class="shareFrame"></iframe>');
@@ -111,7 +111,7 @@ export class ShareDialogue extends Dialogue {
         // this.$image = $('<img class="share" />');
         // this.$embedView.append(this.$image);
 
-        this.$code = $(`<input class="code" type="text" readonly aria-label="${this.content.embed }"/>`);
+        this.$code = $(`<input class="code" type="text" readonly="readonly" aria-label="${this.content.embed }"/>`);
         this.$embedView.append(this.$code);
 
         this.$customSize = $('<div class="customSize"></div>');

--- a/src/modules/uv-filelinkcenterpanel-module/FileLinkCenterPanel.ts
+++ b/src/modules/uv-filelinkcenterpanel-module/FileLinkCenterPanel.ts
@@ -22,13 +22,13 @@ export class FileLinkCenterPanel extends CenterPanel {
             this.openMedia(resources);
         });
 
-        this.$scroll = $('<div class="scroll"><div>');
+        this.$scroll = $('<div class="scroll"></div>');
         this.$content.append(this.$scroll);
 
         this.$downloadItems = $('<ol></ol>');
         this.$scroll.append(this.$downloadItems);
 
-        this.$downloadItemTemplate = $('<li><img><div class="col2"><a class="filename" target="_blank" download></a><span class="label"></span><a class="description" target="_blank" download></a></div></li>');
+        this.$downloadItemTemplate = $('<li><img/><div class="col2"><a class="filename" target="_blank" download=""></a><span class="label"></span><a class="description" target="_blank" download=""></a></div></li>');
 
         this.title = this.extension.helper.getLabel();
     }

--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -117,7 +117,7 @@ export class FooterPanel extends BaseFooterPanel {
         this.$previousResultButton = $('<a class="previousResult" title="' + this.content.previousResult + '">' + this.content.previousResult + '</a>');
         this.$searchPagerControls.append(this.$previousResultButton);
 
-        this.$searchResultsInfo = $('<div class="searchResultsInfo"><span class="info"><span class="number">x</span> <span class="foundFor"></span> \'<span class="terms">y</span>\'<?span></div>');
+        this.$searchResultsInfo = $('<div class="searchResultsInfo"><span class="info"><span class="number">x</span> <span class="foundFor"></span> \'<span class="terms">y</span>\'</span></div>');
         this.$searchPagerControls.append(this.$searchResultsInfo);
 
         this.$clearSearchResultsButton = $('<a class="clearSearch" title="' + this.content.clearSearch + '">' + this.content.clearSearch + '</a>');

--- a/src/modules/uv-shared-module/CenterPanel.ts
+++ b/src/modules/uv-shared-module/CenterPanel.ts
@@ -51,7 +51,7 @@ export class CenterPanel extends BaseView {
                                   <div class="header">
                                     <div class="title"></div>
                                     <button type="button" class="close" aria-label="Close">
-                                      <span aria-hidden="true">&times;</span>
+                                      <span aria-hidden="true">&#215;</span>
                                     </button>
                                   </div>
                                   <div class="main">

--- a/src/modules/uv-shared-module/HeaderPanel.ts
+++ b/src/modules/uv-shared-module/HeaderPanel.ts
@@ -62,7 +62,7 @@ export class HeaderPanel extends BaseView {
                                     <div class="message"></div> \
                                     <div class="actions"></div> \
                                     <button type="button" class="close" aria-label="Close"> \
-                                        <span aria-hidden="true">&times;</span>\
+                                        <span aria-hidden="true">&#215;</span>\
                                     </button> \
                                   </div>');
 


### PR DESCRIPTION
These changes get some way towards making UV compatible with XHTML 5. There remain some incompatibilities brought in as dependencies in the build process, which will need to be fixed upstream before full compatibility is achieved.

There are three types of problem that need to be fixed: 

1. Attributes must have explicit, quoted, values.
2. Named character entities other than `&quot;`, `&apos;`, `&lt;`, `&gt;`, and `&amp;` are not allowed.
3. All markup must be well-formed
