### PR TITLE
fix typo; error when hitting search button with no value

### DIFF
--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -378,7 +378,7 @@ export class FooterPanel extends BaseFooterPanel {
         this.terms = terms;
 
         if (this.terms === '' || this.terms === this.content.enterKeyword) {
-            this.extension.showMessage(this.config.modules.genericDialogue.content.emptyValue, function(){
+            this.extension.showMessage(this.extension.data.config.modules.genericDialogue.content.emptyValue, function(){
                 this.$searchText.focus();
             });
 


### PR DESCRIPTION
When you hit the search button in the footer panel, and the query is empty,
you'll get an javascript error in the console (not noticeable by the user):

```
Uncaught TypeError: Cannot read property 'genericDialogue' of undefined
    at FooterPanel.search (FooterPanel.js:282)
    at HTMLAnchorElement.<anonymous> (FooterPanel.js:103)
    at HTMLAnchorElement.dispatch (offline.js:2)
    at HTMLAnchorElement.y.handle (offline.js:2)
```
Reason: typo