### PR TITLE
Adding translation into header of PDF view.

### DIFF
--- a/src/extensions/uv-pdf-extension/l10n/cy-GB.json
+++ b/src/extensions/uv-pdf-extension/l10n/cy-GB.json
@@ -42,6 +42,23 @@
         "ok": "GWELD"
       }
     },
+    "headerPanel": {
+      "content": {
+        "close": "Cau",
+        "help": "Help"
+      }
+    },
+    "pdfHeaderPanel": {
+      "content": {
+        "emptyValue": "Rhowch werth",
+        "first": "Gyntaf",
+        "go": "Ewch",
+        "last": "Diwethaf",
+        "next": "Nesaf",
+        "of": "o {0}",
+        "previous": "Blaenorol"
+      }
+    },
     "helpDialogue": {
       "content": {
         "text": "testun i'w osod",

--- a/src/extensions/uv-pdf-extension/l10n/fr-FR.json
+++ b/src/extensions/uv-pdf-extension/l10n/fr-FR.json
@@ -90,6 +90,23 @@
                 "refresh": "Rafraîchir"
             }
         },
+        "headerPanel": {
+            "content": {
+              "close": "Fermer",
+              "help": "Aide"
+            }
+          },
+          "pdfHeaderPanel": {
+            "content": {
+              "emptyValue": "Entrer un nombre",
+              "first": "Premier",
+              "go": "Aller",
+              "last": "Dernière",
+              "next": "Aide",
+              "of": "de {0}",
+              "previous": "Précédent"
+            }
+          },
         "helpDialogue": {
             "content": {
                 "text": "texte d'exemple",

--- a/src/extensions/uv-pdf-extension/l10n/sv-SE.json
+++ b/src/extensions/uv-pdf-extension/l10n/sv-SE.json
@@ -90,6 +90,23 @@
                 "refresh": "Uppdatera"
             }
         },
+        "headerPanel": {
+            "content": {
+              "close": "Stäng",
+              "help": "Hjälp"
+            }
+          },
+          "pdfHeaderPanel": {
+            "content": {
+              "emptyValue": "Geben Sie eine Nummer ein",
+              "first": "Första",
+              "go": "Gå",
+              "last": "Sista",
+              "next": "Hjälp",
+              "of": "av {0}",
+              "previous": "Föregående"
+            }
+          },
         "helpDialogue": {
             "content": {
                 "text": "platshållartext",

--- a/src/extensions/uv-pdf-extension/theme/treeviewleftpanel.less
+++ b/src/extensions/uv-pdf-extension/theme/treeviewleftpanel.less
@@ -27,4 +27,14 @@
             }
         }
     }
+
+    .headerPanel {
+
+        .centerOptions {
+
+            .search {
+                width: 123px;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixing issue where the Welsh and other translations were not displaying in the header when on the PDF viewer.

Currently the buttons show as 'undefined' when changing to a language other than English

http://universalviewer.io/examples/?manifest=http://wellcomelibrary.org/iiif/b17502792/manifest#?c=&m=&s=&cv=&manifest=https%3A%2F%2Fedsilv.github.io%2Ftest-manifests%2Fpres3-pdf.json