### PR TITLE
Use credentialed requests for PDFs when auth services present

### DIFF
--- a/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -257,7 +257,7 @@ export class PDFCenterPanel extends CenterPanel {
 
                 var parameter = {
                     url: mediaUri,
-                    withCredentials: true
+                    withCredentials: canvas.externalResource.isAccessControlled()
                   } 
 
                 PDFJS.getDocument(parameter).then((pdfDoc: any) => {

--- a/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -255,7 +255,12 @@ export class PDFCenterPanel extends CenterPanel {
             } else {
                 PDFJS.disableWorker = true;
 
-                PDFJS.getDocument(mediaUri).then((pdfDoc: any) => {
+                var parameter = {
+                    url: mediaUri,
+                    withCredentials: true
+                  } 
+
+                PDFJS.getDocument(parameter).then((pdfDoc: any) => {
                     this._pdfDoc = pdfDoc;
                     this._render(this._pageIndex);
 


### PR DESCRIPTION
Small change to make PDF.js use credentialed requests if the canvas has auth services, allowing PDFs to be used with the proto-auth 2.x probe service