### PR TITLE
Accessibility Improvements (webpack)

### DIFF
--- a/src/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -169,7 +169,7 @@ export class ContentLeftPanel extends LeftPanel {
     this.$treeView = $('<div class="treeView"></div>');
     this.$views.append(this.$treeView);
 
-    this.$thumbsView = $('<div class="thumbsView" tabindex="0"></div>');
+    this.$thumbsView = $('<div class="thumbsView" tabindex="-1"></div>');
     this.$views.append(this.$thumbsView);
 
     this.$galleryView = $('<div class="galleryView"></div>');

--- a/src/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -117,7 +117,6 @@ export class ContentLeftPanel extends LeftPanel {
     this.$thumbsButton = $(
       '<a class="thumbs tab" tabindex="0">' + this.content.thumbnails + "</a>"
     );
-    this.$thumbsButton.prop("title", this.content.thumbnails);
     this.$tabs.append(this.$thumbsButton);
 
     this.$tabsContent = $('<div class="tabsContent"></div>');
@@ -374,7 +373,6 @@ export class ContentLeftPanel extends LeftPanel {
 
   setTreeTabTitle(title: string): void {
     this.$treeButton.text(title);
-    this.$treeButton.prop("title", title);
   }
 
   updateTreeTabBySelection(): void {

--- a/src/modules/uv-dialogues-module/DownloadDialogue.ts
+++ b/src/modules/uv-dialogues-module/DownloadDialogue.ts
@@ -44,7 +44,7 @@ export class DownloadDialogue extends Dialogue {
     });
 
     // create ui.
-    this.$title = $("<h1>" + this.content.title + "</h1>");
+    this.$title = $("<h2>" + this.content.title + "</h2>");
     this.$content.append(this.$title);
 
     this.$noneAvailable = $(

--- a/src/modules/uv-dialogues-module/ShareDialogue.ts
+++ b/src/modules/uv-dialogues-module/ShareDialogue.ts
@@ -77,13 +77,11 @@ export class ShareDialogue extends Dialogue {
     this.$shareButton = $(
       '<a class="share tab default" tabindex="0">' + this.content.share + "</a>"
     );
-    this.$shareButton.prop("title", this.content.share);
     this.$tabs.append(this.$shareButton);
 
     this.$embedButton = $(
       '<a class="embed tab" tabindex="0">' + this.content.embed + "</a>"
     );
-    this.$embedButton.prop("title", this.content.embed);
     this.$tabs.append(this.$embedButton);
 
     this.$tabsContent = $('<div class="tabsContent"></div>');

--- a/src/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -251,21 +251,25 @@ export class OpenSeadragonCenterPanel extends CenterPanel {
     this.$zoomInButton = this.$viewer.find('div[title="Zoom in"]');
     this.$zoomInButton.attr("tabindex", 0);
     this.$zoomInButton.prop("title", this.content.zoomIn);
+    this.$zoomInButton.prop("aria-label", this.content.zoomIn);
     this.$zoomInButton.addClass("zoomIn viewportNavButton");
 
     this.$zoomOutButton = this.$viewer.find('div[title="Zoom out"]');
     this.$zoomOutButton.attr("tabindex", 0);
     this.$zoomOutButton.prop("title", this.content.zoomOut);
+    this.$zoomOutButton.prop("aria-label", this.content.zoomOut);
     this.$zoomOutButton.addClass("zoomOut viewportNavButton");
 
     this.$goHomeButton = this.$viewer.find('div[title="Go home"]');
     this.$goHomeButton.attr("tabindex", 0);
     this.$goHomeButton.prop("title", this.content.goHome);
+    this.$goHomeButton.prop("aria-label", this.content.goHome);
     this.$goHomeButton.addClass("goHome viewportNavButton");
 
     this.$rotateButton = this.$viewer.find('div[title="Rotate right"]');
     this.$rotateButton.attr("tabindex", 0);
     this.$rotateButton.prop("title", this.content.rotateRight);
+    this.$rotateButton.prop("aria-label", this.content.rotateRight);
     this.$rotateButton.addClass("rotate viewportNavButton");
 
     this.$viewportNavButtonsContainer = this.$viewer.find(

--- a/src/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -76,14 +76,16 @@ export class PagingHeaderPanel extends HeaderPanel {
 
     this.$firstButton = $(`
           <button class="btn imageBtn first" tabindex="0" title="${this.content.first}">
-            <i class="uv-icon-first" aria-hidden="true"></i><span>${this.content.first}</span>
+            <i class="uv-icon-first" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.first}</span>
           </button>
         `);
     this.$prevOptions.append(this.$firstButton);
 
     this.$prevButton = $(`
           <button class="btn imageBtn prev" tabindex="0" title="${this.content.previous}">
-            <i class="uv-icon-prev" aria-hidden="true"></i><span>${this.content.previous}</span>
+            <i class="uv-icon-prev" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.previous}</span>
           </button>
         `);
     this.$prevOptions.append(this.$prevButton);
@@ -214,14 +216,16 @@ export class PagingHeaderPanel extends HeaderPanel {
 
     this.$nextButton = $(`
           <button class="btn imageBtn next" tabindex="0" title="${this.content.next}">
-            <i class="uv-icon-next" aria-hidden="true"></i><span>${this.content.next}</span>
+            <i class="uv-icon-next" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.next}</span>
           </button>
         `);
     this.$nextOptions.append(this.$nextButton);
 
     this.$lastButton = $(`
           <button class="btn imageBtn last" tabindex="0" title="${this.content.last}">
-            <i class="uv-icon-last" aria-hidden="true"></i><span>${this.content.last}</span>
+            <i class="uv-icon-last" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.last}</span>
           </button>
         `);
     this.$nextOptions.append(this.$lastButton);
@@ -244,8 +248,9 @@ export class PagingHeaderPanel extends HeaderPanel {
     }
 
     this.$galleryButton = $(`
-          <button class="btn imageBtn gallery" title="${this.content.gallery}" tabindex="0">
-            <i class="uv-icon-gallery" aria-hidden="true"></i>${this.content.gallery}
+          <button class="btn imageBtn gallery" title="${this.content.gallery}">
+            <i class="uv-icon-gallery" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.gallery}</span>
           </button>
         `);
     this.$rightOptions.prepend(this.$galleryButton);
@@ -254,14 +259,16 @@ export class PagingHeaderPanel extends HeaderPanel {
     this.$rightOptions.prepend(this.$pagingToggleButtons);
 
     this.$oneUpButton = $(`
-          <button class="btn imageBtn one-up" title="${this.content.oneUp}" tabindex="0">
-            <i class="uv-icon-one-up" aria-hidden="true"></i>${this.content.oneUp}
+          <button class="btn imageBtn one-up" title="${this.content.oneUp}">
+            <i class="uv-icon-one-up" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.oneUp}</span>
           </button>`);
     this.$pagingToggleButtons.append(this.$oneUpButton);
 
     this.$twoUpButton = $(`
-          <button class="btn imageBtn two-up" title="${this.content.twoUp}" tabindex="0">
-            <i class="uv-icon-two-up" aria-hidden="true"></i>${this.content.twoUp}
+          <button class="btn imageBtn two-up" title="${this.content.twoUp}">
+            <i class="uv-icon-two-up" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.twoUp}</span>
           </button>
         `);
     this.$pagingToggleButtons.append(this.$twoUpButton);

--- a/src/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -205,7 +205,7 @@ export class PagingHeaderPanel extends HeaderPanel {
     this.$search.append(this.$total);
 
     this.$searchButton = $(
-      `<a class="go btn btn-primary" title="${this.content.go}" tabindex="0">${this.content.go}</a>`
+      `<a class="go btn btn-primary" tabindex="0">${this.content.go}</a>`
     );
     this.$search.append(this.$searchButton);
 

--- a/src/modules/uv-pagingheaderpanel-module/css/styles.less
+++ b/src/modules/uv-pagingheaderpanel-module/css/styles.less
@@ -7,7 +7,6 @@
         color: @text-secondary-color;
 
         button.btn.imageBtn {
-            font-size: 0;
             padding-left: 2px;
             padding-right: 2px;
 

--- a/src/modules/uv-pagingheaderpanel-module/css/styles.less
+++ b/src/modules/uv-pagingheaderpanel-module/css/styles.less
@@ -1,4 +1,4 @@
-@import 'icons';﻿
+@import 'icons';
 
 .uv {
 
@@ -23,13 +23,11 @@
                 }
             }
 
-            &.disabled {
-                opacity: 0.4;
-                filter: alpha(opacity=40);
+            &.disabled,
+            &.disabled:hover,
+            &.disabled i,
+            &.disabled i:hover {
                 background-color: transparent;
-                &:hover {
-                    background-color: transparent;
-                }
             }
         }
 

--- a/src/modules/uv-pdfheaderpanel-module/css/styles.less
+++ b/src/modules/uv-pdfheaderpanel-module/css/styles.less
@@ -7,7 +7,6 @@
         color: @text-secondary-color;
 
         button.btn.imageBtn {
-            font-size: 0;
             padding-left: 2px;
             padding-right: 2px;
 

--- a/src/modules/uv-pdfheaderpanel-module/css/styles.less
+++ b/src/modules/uv-pdfheaderpanel-module/css/styles.less
@@ -23,13 +23,11 @@
                 }
             }
 
-            &.disabled {
-                opacity: 0.4;
-                filter: alpha(opacity=40);
+            &.disabled,
+            &.disabled:hover,
+            &.disabled i,
+            &.disabled i:hover {
                 background-color: transparent;
-                &:hover {
-                    background-color: transparent;
-                }
             }
         }
 

--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -103,7 +103,7 @@ export class FooterPanel extends BaseFooterPanel {
     this.$searchContainer.append(this.$searchOptions);
 
     this.$searchLabel = $(
-      '<span class="label">' + this.content.searchWithin + "</span>"
+      '<label class="label" for="searchWithinInput">' + this.content.searchWithin + "</label>"
     );
     this.$searchOptions.append(this.$searchLabel);
 
@@ -111,7 +111,7 @@ export class FooterPanel extends BaseFooterPanel {
     this.$searchOptions.append(this.$searchTextContainer);
 
     this.$searchText = $(
-      '<input class="searchText" type="text" maxlength="100" value="' +
+      '<input class="searchText" id="searchWithinInput" type="text" maxlength="100" value="' +
         this.content.enterKeyword +
         '" aria-label="' +
         this.content.searchWithin +

--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -132,11 +132,7 @@ export class FooterPanel extends BaseFooterPanel {
     this.$searchPagerContainer.prepend(this.$searchPagerControls);
 
     this.$previousResultButton = $(
-      '<a class="previousResult" title="' +
-        this.content.previousResult +
-        '">' +
-        this.content.previousResult +
-        "</a>"
+      '<a class="previousResult">' + this.content.previousResult + "</a>"
     );
     this.$searchPagerControls.append(this.$previousResultButton);
 
@@ -146,20 +142,12 @@ export class FooterPanel extends BaseFooterPanel {
     this.$searchPagerControls.append(this.$searchResultsInfo);
 
     this.$clearSearchResultsButton = $(
-      '<a class="clearSearch" title="' +
-        this.content.clearSearch +
-        '">' +
-        this.content.clearSearch +
-        "</a>"
+      '<a class="clearSearch">' + this.content.clearSearch + "</a>"
     );
     this.$searchResultsInfo.append(this.$clearSearchResultsButton);
 
     this.$nextResultButton = $(
-      '<a class="nextResult" title="' +
-        this.content.nextResult +
-        '">' +
-        this.content.nextResult +
-        "</a>"
+      '<a class="nextResult">' + this.content.nextResult + "</a>"
     );
     this.$searchPagerControls.append(this.$nextResultButton);
 

--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -120,7 +120,7 @@ export class FooterPanel extends BaseFooterPanel {
     this.$searchTextContainer.append(this.$searchText);
 
     this.$searchButton = $(
-      '<a class="imageButton searchButton" tabindex="0"></a>'
+      '<button class="imageButton searchButton"></button>'
     );
     this.$searchTextContainer.append(this.$searchButton);
 
@@ -132,7 +132,7 @@ export class FooterPanel extends BaseFooterPanel {
     this.$searchPagerContainer.prepend(this.$searchPagerControls);
 
     this.$previousResultButton = $(
-      '<a class="previousResult">' + this.content.previousResult + "</a>"
+      '<button class="previousResult">' + this.content.previousResult + "</button>"
     );
     this.$searchPagerControls.append(this.$previousResultButton);
 
@@ -142,12 +142,12 @@ export class FooterPanel extends BaseFooterPanel {
     this.$searchPagerControls.append(this.$searchResultsInfo);
 
     this.$clearSearchResultsButton = $(
-      '<a class="clearSearch">' + this.content.clearSearch + "</a>"
+      '<button class="clearSearch">' + this.content.clearSearch + "</button>"
     );
     this.$searchResultsInfo.append(this.$clearSearchResultsButton);
 
     this.$nextResultButton = $(
-      '<a class="nextResult">' + this.content.nextResult + "</a>"
+      '<button class="nextResult">' + this.content.nextResult + "</button>"
     );
     this.$searchPagerControls.append(this.$nextResultButton);
 

--- a/src/modules/uv-searchfooterpanel-module/css/styles.less
+++ b/src/modules/uv-searchfooterpanel-module/css/styles.less
@@ -159,12 +159,13 @@
                     }
                 }
 
-                a.imageButton.searchButton{
+                .imageButton.searchButton{
                     background: data-uri('@{img-path}search.png');
                     background-repeat: no-repeat;
                     height: 18px;
                     width: 18px;
                     margin: 2px 2px 0 0;
+                    border: 0;
                     float: right;
                     cursor: pointer;
                 }
@@ -197,36 +198,49 @@
                 // margin: @margin-small-vertical 0 0 0;
                 width: 585px;
 
-                a.previousResult{
+                .previousResult{
                     .noselect();
                     .icon-left('@{img-path}prev.png', 30px, 25px);
                     line-height: 30px;
                     float: left;
                     margin: 0 @margin-medium-horizontal 0 0;
+                    border: 0;
+                    color: #000;
+
+                    &:hover {
+                        color: #000;
+                    }
 
                     &.disabled {
                         .opacity(.25);
                     }
                 }
 
-                a.nextResult{
+                .nextResult{
                     .noselect();
                     .icon-right('@{img-path}next.png', 30px, 25px);
                     line-height: 30px;
                     float: right;
                     margin: 0 0 0 @margin-medium-horizontal;
+                    border: 0;
+                    color: #000;
+
+                    &:hover {
+                        color: #000;
+                    }
 
                     &.disabled {
                         .opacity(.25);
                     }
                 }
 
-                a.clearSearch{
+                .clearSearch{
                     .noselect();
                     cursor: pointer;
                     color: @link-color;
                     text-decoration: none;
                     margin: 0 0 0 @margin-medium-horizontal;
+                    border: 0;
                     font-size: 12px;
                 }
 

--- a/src/modules/uv-shared-module/AutoComplete.ts
+++ b/src/modules/uv-shared-module/AutoComplete.ts
@@ -132,6 +132,12 @@ export class AutoComplete {
       }
     });
 
+    // hide results if focus moves on.
+    this._$element.on("focusout", e => {
+      this._clearResults();
+      this._hideResults();
+    });
+
     this._hideResults();
   }
 

--- a/src/modules/uv-shared-module/AutoComplete.ts
+++ b/src/modules/uv-shared-module/AutoComplete.ts
@@ -133,9 +133,14 @@ export class AutoComplete {
     });
 
     // hide results if focus moves on.
-    this._$element.on("focusout", e => {
-      this._clearResults();
-      this._hideResults();
+    $(document).on("focusin", e => {
+      if (
+        this._$searchResultsList.has($(e.target)[0]).length === 0 &&
+        !this._$element.is($(e.target)[0])
+      ) {
+        this._clearResults();
+        this._hideResults();
+      }
     });
 
     this._hideResults();

--- a/src/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/modules/uv-shared-module/BaseExpandPanel.ts
@@ -27,7 +27,7 @@ export class BaseExpandPanel extends BaseView {
     this.$top = $('<div class="top"></div>');
     this.$element.append(this.$top);
 
-    this.$title = $('<div class="title"></div>');
+    this.$title = $('<h2 class="title"></h2>');
     this.$top.append(this.$title);
 
     this.$expandFullButton = $('<a class="expandFullButton" tabindex="0"></a>');

--- a/src/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/modules/uv-shared-module/BaseExpandPanel.ts
@@ -28,11 +28,9 @@ export class BaseExpandPanel extends BaseView {
     this.$element.append(this.$top);
 
     this.$title = $('<div class="title"></div>');
-    this.$title.prop("title", this.content.title);
     this.$top.append(this.$title);
 
     this.$expandFullButton = $('<a class="expandFullButton" tabindex="0"></a>');
-    this.$expandFullButton.prop("title", this.content.expandFull);
     this.$top.append(this.$expandFullButton);
 
     if (!Bools.getBool(this.config.options.expandFullEnabled, true)) {
@@ -40,18 +38,15 @@ export class BaseExpandPanel extends BaseView {
     }
 
     this.$collapseButton = $('<div class="collapseButton" tabindex="0"></div>');
-    this.$collapseButton.prop("title", this.content.collapse);
     this.$top.append(this.$collapseButton);
 
     this.$closed = $('<div class="closed"></div>');
     this.$element.append(this.$closed);
 
     this.$expandButton = $('<a class="expandButton" tabindex="0"></a>');
-    this.$expandButton.prop("title", this.content.expand);
     this.$closed.append(this.$expandButton);
 
     this.$closedTitle = $('<a class="title"></a>');
-    this.$closedTitle.prop("title", this.content.title);
     this.$closed.append(this.$closedTitle);
 
     this.$main = $('<div class="main"></div>');

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -98,7 +98,7 @@ export class BaseExtension implements IExtension {
     this.$element.addClass(this.name);
     this.$element.addClass("browser-" + window.browserDetect.browser);
     this.$element.addClass("browser-version-" + window.browserDetect.version);
-    this.$element.prop("tabindex", 0);
+    this.$element.prop("tabindex", -1);
 
     if (this.data.embedded) {
       this.$element.addClass("embedded");

--- a/src/modules/uv-shared-module/BaseExtension.ts
+++ b/src/modules/uv-shared-module/BaseExtension.ts
@@ -246,7 +246,7 @@ export class BaseExtension implements IExtension {
       this.component.publish(BaseEvents.RESIZE);
     });
 
-    this.$element.append('<a href="/" id="top"></a>');
+    // this.$element.append('<a href="/" id="top"></a>');
     this.$element.append(
       '<iframe id="commsFrame" style="display:none"></iframe>'
     );

--- a/src/modules/uv-shared-module/FooterPanel.ts
+++ b/src/modules/uv-shared-module/FooterPanel.ts
@@ -46,57 +46,65 @@ export class FooterPanel extends BaseView {
     this.$element.append(this.$options);
 
     this.$feedbackButton = $(`
-          <button class="feedback btn imageBtn" title="${this.content.feedback}" tabindex="0">
-            <i class="uv-icon uv-icon-feedback" aria-hidden="true"></i>${this.content.feedback}
+          <button class="feedback btn imageBtn" title="${this.content.feedback}">
+            <i class="uv-icon uv-icon-feedback" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.feedback}</span>
           </button>
         `);
     this.$options.prepend(this.$feedbackButton);
 
     this.$openButton = $(`
-          <button class="open btn imageBtn" title="${this.content.open}" tabindex="0">
-            <i class="uv-icon-open" aria-hidden="true"></i>${this.content.open}
+          <button class="open btn imageBtn" title="${this.content.open}">
+            <i class="uv-icon-open" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.open}</span>
           </button>
         `);
     this.$options.prepend(this.$openButton);
 
     this.$bookmarkButton = $(`
-          <button class="bookmark btn imageBtn" title="${this.content.bookmark}" tabindex="0">
-            <i class="uv-icon uv-icon-bookmark" aria-hidden="true"></i>${this.content.bookmark}
+          <button class="bookmark btn imageBtn" title="${this.content.bookmark}">
+            <i class="uv-icon uv-icon-bookmark" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.bookmark}</span>
           </button>
         `);
     this.$options.prepend(this.$bookmarkButton);
 
     this.$shareButton = $(`
-          <button class="share btn imageBtn" title="${this.content.share}" tabindex="0">
-            <i class="uv-icon uv-icon-share" aria-hidden="true"></i>${this.content.share}
+          <button class="share btn imageBtn" title="${this.content.share}">
+            <i class="uv-icon uv-icon-share" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.share}</span>
           </button>
         `);
     this.$options.append(this.$shareButton);
 
     this.$embedButton = $(`
-          <button class="embed btn imageBtn" title="${this.content.embed}" tabindex="0">
-            <i class="uv-icon uv-icon-embed" aria-hidden="true"></i>${this.content.embed}
+          <button class="embed btn imageBtn" title="${this.content.embed}">
+            <i class="uv-icon uv-icon-embed" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.embed}</span>
           </button>
         `);
     this.$options.append(this.$embedButton);
 
     this.$downloadButton = $(`
-          <button class="download btn imageBtn" title="${this.content.download}" tabindex="0">
-            <i class="uv-icon uv-icon-download" aria-hidden="true"></i>${this.content.download}
+          <button class="download btn imageBtn" title="${this.content.download}">
+            <i class="uv-icon uv-icon-download" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.download}</span>
           </button>
         `);
     this.$options.prepend(this.$downloadButton);
 
     this.$moreInfoButton = $(`
-          <button class="moreInfo btn imageBtn" title="${this.content.moreInfo}" tabindex="0">
-            <i class="uv-icon uv-icon-more-info" aria-hidden="true"></i>${this.content.moreInfo}
+          <button class="moreInfo btn imageBtn" title="${this.content.moreInfo}">
+            <i class="uv-icon uv-icon-more-info" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.moreInfo}</span>
           </button>
         `);
     this.$options.prepend(this.$moreInfoButton);
 
     this.$fullScreenBtn = $(`
-          <button class="fullScreen btn imageBtn" title="${this.content.fullScreen}" tabindex="0">
-            <i class="uv-icon uv-icon-fullscreen" aria-hidden="true"></i>${this.content.fullScreen}
+          <button class="fullScreen btn imageBtn" title="${this.content.fullScreen}">
+            <i class="uv-icon uv-icon-fullscreen" aria-hidden="true"></i>
+            <span class="sr-only">${this.content.fullScreen}</span>
           </button>
         `);
     this.$options.append(this.$fullScreenBtn);

--- a/src/modules/uv-shared-module/FooterPanel.ts
+++ b/src/modules/uv-shared-module/FooterPanel.ts
@@ -86,7 +86,7 @@ export class FooterPanel extends BaseView {
     this.$options.append(this.$embedButton);
 
     this.$downloadButton = $(`
-          <button class="download btn imageBtn" title="${this.content.download}">
+          <button class="download btn imageBtn" title="${this.content.download}" id="download-btn">
             <i class="uv-icon uv-icon-download" aria-hidden="true"></i>
             <span class="sr-only">${this.content.download}</span>
           </button>

--- a/src/modules/uv-shared-module/HeaderPanel.ts
+++ b/src/modules/uv-shared-module/HeaderPanel.ts
@@ -54,7 +54,7 @@ export class HeaderPanel extends BaseView {
 
     this.$settingsButton = $(`
           <button class="btn imageBtn settings" tabindex="0" title="${this.content.settings}">
-            <i class="uv-icon-settings" aria-hidden="true"></i>${this.content.settings}
+            <i class="uv-icon-settings" aria-hidden="true"></i>
           </button>
         `);
     this.$settingsButton.attr("title", this.content.settings);

--- a/src/modules/uv-shared-module/Shell.ts
+++ b/src/modules/uv-shared-module/Shell.ts
@@ -29,6 +29,10 @@ export class Shell extends BaseView {
       this.$overlays.hide();
     });
 
+    // Jump link
+    // TODO: Needs internationalization
+    this.$element.append('<a class="sr-only" href="#download-btn">Skip to downloads and alternative formats</a>');
+
     this.$headerPanel = $('<div class="headerPanel"></div>');
     this.$element.append(this.$headerPanel);
 
@@ -36,6 +40,7 @@ export class Shell extends BaseView {
     this.$element.append(this.$mainPanel);
 
     this.$centerPanel = $('<div class="centerPanel"></div>');
+    // TODO: Needs internationalization
     this.$centerPanel.append('<h2 class="sr-only">Media Viewer</h2>');
     this.$mainPanel.append(this.$centerPanel);
 

--- a/src/modules/uv-shared-module/Shell.ts
+++ b/src/modules/uv-shared-module/Shell.ts
@@ -36,6 +36,7 @@ export class Shell extends BaseView {
     this.$element.append(this.$mainPanel);
 
     this.$centerPanel = $('<div class="centerPanel"></div>');
+    this.$centerPanel.append('<h2 class="sr-only">Media Viewer</h2>');
     this.$mainPanel.append(this.$centerPanel);
 
     this.$leftPanel = $('<div class="leftPanel"></div>');

--- a/src/modules/uv-shared-module/ThumbsView.ts
+++ b/src/modules/uv-shared-module/ThumbsView.ts
@@ -2,7 +2,8 @@ import { BaseEvents } from "./BaseEvents";
 import { BaseView } from "./BaseView";
 import { ExternalResourceType, ViewingDirection } from "@iiif/vocabulary";
 import { Annotation, AnnotationBody, Canvas, Thumb } from "manifesto.js";
-import { Dates, Maths, Strings } from "@edsilv/utils";
+import * as KeyCodes from "@edsilv/key-codes";
+import { Dates, Keyboard, Maths, Strings } from "@edsilv/utils";
 
 export class ThumbsView extends BaseView {
   private _$thumbsCache: JQuery | null;
@@ -46,14 +47,14 @@ export class ThumbsView extends BaseView {
 
     $.templates({
       thumbsTemplate:
-        '<div id="thumb{{>index}}" class="{{:~className()}}" data-src="{{>uri}}" data-visible="{{>visible}}" data-index="{{>index}}">\
+        '<a id="thumb{{>index}}" class="{{:~className()}}" data-src="{{>uri}}" data-visible="{{>visible}}" data-index="{{>index}}" tabindex="0">\
                                 <div class="wrap" style="height:{{>height + ~extraHeight()}}px"></div>\
                                 <div class="info">\
                                     <span class="index">{{:#index + 1}}</span>\
                                     <span class="label" title="{{>label}}">{{>label}}&nbsp;</span>\
                                     <span class="searchResults" title="{{:~searchResultsTitle()}}">{{>data.searchResults}}</span>\
                                 </div>\
-                             </div>\
+                             </a>\
                              {{if ~separator()}} \
                                  <div class="separator"></div> \
                              {{/if}}'
@@ -166,6 +167,22 @@ export class ThumbsView extends BaseView {
       const data = $.view(this).data;
       that.lastThumbClickedIndex = data.index;
       that.component.publish(BaseEvents.THUMB_SELECTED, data);
+      return false;
+    });
+
+    // Support keyboard navigation (spacebar / enter)
+    this.$thumbs.delegate(".thumb", "keydown", function(e: JQueryEventObject) {
+      const originalEvent: KeyboardEvent = <KeyboardEvent>e.originalEvent;
+      const charCode: number = Keyboard.getCharCode(originalEvent);
+      if (
+        charCode === KeyCodes.KeyDown.Spacebar ||
+        charCode === KeyCodes.KeyDown.Enter
+      ) {
+        e.preventDefault();
+        const data = $.view(this).data;
+        that.lastThumbClickedIndex = data.index;
+        that.component.publish(BaseEvents.THUMB_SELECTED, data);
+      }
     });
 
     this.setLabel();

--- a/src/modules/uv-shared-module/css/header-panel.less
+++ b/src/modules/uv-shared-module/css/header-panel.less
@@ -10,10 +10,6 @@
                 height: 30px;
                 width: 30px;
             }
-
-            span {
-                .sr-only();
-            }
         }
 
         &.showInformation {

--- a/src/modules/uv-shared-module/css/header-panel.less
+++ b/src/modules/uv-shared-module/css/header-panel.less
@@ -10,7 +10,10 @@
                 height: 30px;
                 width: 30px;
             }
-            .hide-text();
+
+            span {
+                .sr-only();
+            }
         }
 
         &.showInformation {
@@ -54,7 +57,7 @@
             .message {
                 float: left;
                 margin: 13px;
-                white-space: nowrap; 
+                white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
             }

--- a/src/modules/uv-shared-module/css/left-panel.less
+++ b/src/modules/uv-shared-module/css/left-panel.less
@@ -18,6 +18,8 @@
             .title {
                 height: 20px;
                 margin: 9px 0 0 10px;
+                font-size: inherit;
+                font-weight: normal;
                 float: left;
                 cursor: pointer;
             }

--- a/src/modules/uv-shared-module/css/mixins.less
+++ b/src/modules/uv-shared-module/css/mixins.less
@@ -80,32 +80,6 @@
     border: 0;
 }
 
-// Screen reader only text hiding
-// https://tailwindcss.com/docs/screen-readers/
-.sr-only() {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
-}
-.not-sr-only() {
-    position: static;
-    width: auto;
-    height: auto;
-    padding: 0;
-    margin: 0;
-    overflow: visible;
-    clip: auto;
-    white-space: normal;
-}
-
-
-
 // CSS3 PROPERTIES
 // --------------------------------------------------
 

--- a/src/modules/uv-shared-module/css/mixins.less
+++ b/src/modules/uv-shared-module/css/mixins.less
@@ -80,6 +80,30 @@
     border: 0;
 }
 
+// Screen reader only text hiding
+// https://tailwindcss.com/docs/screen-readers/
+.sr-only() {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+.not-sr-only() {
+    position: static;
+    width: auto;
+    height: auto;
+    padding: 0;
+    margin: 0;
+    overflow: visible;
+    clip: auto;
+    white-space: normal;
+}
+
 
 
 // CSS3 PROPERTIES

--- a/src/modules/uv-shared-module/css/right-panel.less
+++ b/src/modules/uv-shared-module/css/right-panel.less
@@ -14,6 +14,8 @@
                 position: absolute;
                 height: 20px;
                 margin-top: 9px;
+                font-size: inherit;
+                font-weight: normal;
                 cursor: pointer;
                 left: 35px;
             }

--- a/src/modules/uv-shared-module/css/scaffolding.less
+++ b/src/modules/uv-shared-module/css/scaffolding.less
@@ -129,19 +129,27 @@
     }
 
 
-    // Only display content to screen readers
-    //
-    // See: http://a11yproject.com/posts/how-to-hide-content/
-
+    // Screen reader only text hiding
+    // https://tailwindcss.com/docs/screen-readers/
     .sr-only {
         position: absolute;
         width: 1px;
         height: 1px;
-        margin: -1px;
         padding: 0;
+        margin: -1px;
         overflow: hidden;
-        clip: rect(0 0 0 0);
-        border: 0;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border-width: 0;
     }
-
+    .not-sr-only {
+        position: static;
+        width: auto;
+        height: auto;
+        padding: 0;
+        margin: 0;
+        overflow: visible;
+        clip: auto;
+        white-space: normal;
+    }
 }

--- a/src/modules/uv-shared-module/css/variables.less
+++ b/src/modules/uv-shared-module/css/variables.less
@@ -36,10 +36,10 @@
 // Brand colors
 // -------------------------
 
-@brand-primary:                 #14A2C1; // #14a4c3 tuned for 4.5 contrast with white text
+@brand-primary:                 #10819A; // #14a4c3 tuned for 4.5 contrast with white text
 @brand-primary-light:           lighten(@brand-primary, 60%);
 @brand-primary-lighter:         lighten(@brand-primary, 90%);
-@brand-secondary:               #14A2C1;
+@brand-secondary:               #10819A;
 @brand-warning:                 #FFB81D;
 @brand-success:                 #5cb85c;
 @brand-danger:                  #d9534f;

--- a/src/modules/uv-shared-module/css/variables.less
+++ b/src/modules/uv-shared-module/css/variables.less
@@ -58,7 +58,7 @@
 // Links
 // -------------------------
 
-@link-color:                    #10819A; // #26b5cc tuned for 4.5 contrast on white bg
+@link-color:                    #26b5cc;
 @link-hover-color:              lighten(@link-color, 10%);
 @link-secondary-color:          @brand-secondary;
 @link-secondary-hover-color:    lighten(@link-secondary-color, 10%);

--- a/src/modules/uv-shared-module/css/variables.less
+++ b/src/modules/uv-shared-module/css/variables.less
@@ -36,10 +36,10 @@
 // Brand colors
 // -------------------------
 
-@brand-primary:                 #14a4c3;
+@brand-primary:                 #14A2C1; // #14a4c3 tuned for 4.5 contrast with white text
 @brand-primary-light:           lighten(@brand-primary, 60%);
 @brand-primary-lighter:         lighten(@brand-primary, 90%);
-@brand-secondary:               #14a4c3;
+@brand-secondary:               #14A2C1;
 @brand-warning:                 #FFB81D;
 @brand-success:                 #5cb85c;
 @brand-danger:                  #d9534f;
@@ -58,7 +58,7 @@
 // Links
 // -------------------------
 
-@link-color:                    #26b5cc;
+@link-color:                    #10819A; // #26b5cc tuned for 4.5 contrast on white bg
 @link-hover-color:              lighten(@link-color, 10%);
 @link-secondary-color:          @brand-secondary;
 @link-secondary-hover-color:    lighten(@link-secondary-color, 10%);


### PR DESCRIPTION
Chris and Geoff are evaluating the accessibility of the UV.

## Contrast
- [x] Page dropdown contrast (bg #10819A, alternatively: text color to #2F2F2F or darker)
- [x] Go button contrast (bg #10819A, alternatively: text color to #2F2F2F or darker)
- [x] Link contrast (#10819A)
- [x] Disabled button contrast

## Markup issues
- [x] Zoom button labels
- [x] Font too small (`hide-text() { font: 0/0 a; }`)
  - [x] Fix broken image buttons
- [x] Redundant titles
- [x] [FooterPanel buttons](#discussion_r455865264)
- [x] Search within label (1.1.1) (#750)
  - [ ] Search for `.label` elements

## Screenreader Enhancements
- [x] Add jump link to downloads (alt versions) (1.2.x)
- [x] Add heading above bottom menu
- [x] Improve heading hierarchy (#750)

## Keyboard Support
- [x] Focus on whole iframe likely confusing (`tabindex="-1"`)
- [ ] Navigate nav buttons with arrow keys
- [x] Dropdown doesn't close on unfocus (#457)
- [ ] Cannot tab to page thumbnails
  - [x] Turn div into button or add `tabindex="0"`
  - [x] On select, focus on center panel
  - [ ] On escape, go back to thumbnail (ideal)
- [ ] SeaDragon UI fades out even when UI elements focused (might be out of scope)
- [x] PageUp/Down is good, is it expected behavior?
- [x] `<a href="/" id="top"/>`