### PR TITLE
adding a way to allow large pdfs to zoom to the correct size

### DIFF
--- a/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -314,6 +314,25 @@ export class PDFCenterPanel extends CenterPanel {
             this._canvas.height = this._viewport.height;
             this._canvas.width = this._viewport.width;
 
+
+            // get divisible number between canvas height and content height
+            const divisible_amount = this._canvas.height / this.$content.height()
+            // create a variable for the new canvas height.
+            // (canvas height divided by our divisible_amount) multiply by the viewport scale
+            var canvas_height = (this._canvas.height / divisible_amount) * this._viewport.scale;
+
+            // if canvas height is smaller than our content height
+            // use the content hight instead
+            if(canvas_height < this.$content.height()) {
+                canvas_height = this.$content.height();
+            }
+
+            // set the canvas height with CSS
+            this._$canvas.css({
+                height: canvas_height
+            });
+
+
             // Render PDF page into canvas context
             const renderContext = {
                 canvasContext: this._ctx,


### PR DESCRIPTION
We have an issue where large PDFs aren't rendering to the correct size in the PDF viewer:

e.g https://www.peoplescollection.wales/items/1561611

The example above shows a large PDF being zoomed too far in on page load. 

I believe this is a similar issue to #622.

The work around I have is to set the height of the canvas with CSS. I don't have access to a Windows machine, therefore, I have been unable to check how this works on IE/Edge. But testing locally (OSX), it works on Chrome, Firefox and Safari.

The PDF in my example and the one in #622 work fine.

Diolch/Thanks