### PR TITLE
Use `that` rather than `this` when getting defaultLabel from options …

### DIFF
--- a/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -488,8 +488,8 @@ export class FooterPanel extends BaseFooterPanel {
             const canvas: Canvas = that.extension.helper.getCanvasByIndex(canvasIndex);
             let label: string | null = LanguageMap.getValue(canvas.getLabel());
 
-            if (!label && this.extension.helper.manifest) {
-                label = this.extension.helper.manifest.options.defaultLabel;
+            if (!label && that.extension.helper.manifest) {
+                label = that.extension.helper.manifest.options.defaultLabel;
             }
 
             title = Utils.Strings.format(title, that.content.pageCaps, label as string);


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->
#### Fix placemarker hover on Search Footer place markers when the canvas label is a blank string:
Within searchfooterpanel extension, FooterPanel.ts incorrectly used `this.extensions` to access the default label when the label is blank in the manifest (or otherwise evaluates as false).  This causes an error because `this` does not refer to the FooterPanel.  

This PR uses `that`, which is the FooterPanel so that the defaultLabel is properly used in the $placemarkerDetails.