### PR TITLE
Return false from isVideo if not a video

### DIFF
--- a/src/extensions/uv-mediaelement-extension/Extension.ts
+++ b/src/extensions/uv-mediaelement-extension/Extension.ts
@@ -202,6 +202,8 @@ export class Extension extends BaseExtension implements IMediaElementExtension {
                     }
                 }
             }
+            
+            return false;
 
         } else {
             // @ts-ignore


### PR DESCRIPTION
When a canvas with a `Sound` annotation body type is given, this code will throw `Unable to determine media type` instead of returning false and allowing it to continue with an audio element