### PR TITLE
NPM package publishing

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -1,0 +1,71 @@
+import path from 'path';
+import { build } from 'esbuild';
+import { lessLoader } from 'esbuild-plugin-less';
+import svg from 'esbuild-plugin-svg';
+import fs from 'fs';
+import LessPluginCleanCSS from 'less-plugin-clean-css';
+
+const watch = process.argv[2] === '--watch';
+
+const pkg = JSON.parse(fs.readFileSync('./package.json').toString());
+
+// These are NPM packages that don't work with external bundlers without configuration.
+// To avoid confusion, this will ensure they are included in the ESM bundle.
+const bundledPackages = [
+    'jquery',
+    'jsviews',
+    'xss',
+    '@iiif/vocabulary',
+    '@edsilv/jquery-plugins'
+];
+
+// This plugin will ensure that mediaelement css is loaded correctly. It's currently using a webpack specific
+// format.
+let resolveMediaElement = {
+    name: 'resolve-media-element',
+    setup(build) {
+        // Hack for resolution of webpack specific.
+        build.onResolve({filter: /~mediaelement/}, args => {
+            const t = args.path.split('~mediaelement')[1]
+            return { path: path.join(process.cwd(), './node_modules/mediaelement', t) }
+        });
+    }
+}
+
+async function main() {
+    await build({
+        // Enables code splitting, similar to webpack.
+        splitting: true,
+        outdir: path.resolve(process.cwd(), 'dist/esm'),
+        entryPoints: [path.resolve(process.cwd(), 'src/index.ts')],
+        bundle: true,
+        target: 'es2020',
+        format: 'esm',
+        globalName: 'UV',
+        watch,
+        minify: true,
+        external: [
+            ...Object.keys(pkg.dependencies).filter(t => t.indexOf(bundledPackages) !== -1)
+        ],
+        plugins: [
+            resolveMediaElement,
+            lessLoader({
+                paths: ['node_modules/', './src/modules/uv-shared-module/img', './src/modules/uv-pagingheaderpanel-module/img', './src/modules/uv-openseadragoncenterpanel-module/img', './src/modules/uv-searchfooterpanel-module/img'],
+                math: 'always',
+                javascriptEnabled: true,
+                plugins: [new LessPluginCleanCSS({
+                    advanced: true, level: 2
+                })],
+
+            }),
+            svg()
+        ],
+        loader: {
+            '.ts': 'ts',
+            '.png': 'dataurl',
+            '.gif': 'dataurl',
+        },
+    });
+}
+
+main()

--- a/npm-examples/esbuild/.gitignore
+++ b/npm-examples/esbuild/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+package-lock.json
+yarn.lock

--- a/npm-examples/esbuild/esbuild.mjs
+++ b/npm-examples/esbuild/esbuild.mjs
@@ -1,0 +1,48 @@
+import { build } from 'esbuild';
+import { writeFileSync } from "fs";
+import * as path from 'path';
+import serve, { error, log } from 'create-serve';
+
+const watch = process.argv.includes('--watch') || process.argv.includes('-w');
+
+async function main() {
+    writeFileSync(
+        path.join(process.cwd(), "./dist/index.html"),
+        `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>UV Frontend</title>
+    <link rel="stylesheet" href="./bundle.css" />
+  </head>
+  <body>
+    <div class="uv" id="root"></div>
+    <script src="./bundle.js" type="application/javascript"></script>
+  </body>
+</html>    
+    `
+    );
+
+    build({
+        entryPoints: ["src/index.ts"],
+        outfile: "dist/bundle.js",
+        bundle: true,
+        minify: true,
+        watch: watch && {
+            onRebuild(err) {
+                serve.update();
+                err ? error('× Failed') : log('✓ Updated');
+            }
+        },
+        sourcemap: true,
+        target: ["chrome58"],
+    });
+
+    serve.start({
+        port: 3001,
+        root: 'dist'
+    });
+}
+
+main()

--- a/npm-examples/esbuild/package.json
+++ b/npm-examples/esbuild/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "esbuild-demo",
+  "scripts": {
+    "start": "node esbuild.mjs -w",
+    "build": "node esbuild.mjs"
+  },
+  "dependencies": {
+    "esbuild": "^0.13.12",
+    "create-serve": "^1.0.1",
+    "universalviewer": "../../"
+  }
+}

--- a/npm-examples/esbuild/src/index.ts
+++ b/npm-examples/esbuild/src/index.ts
@@ -1,0 +1,10 @@
+import { init } from 'universalviewer';
+import 'universalviewer/dist/esm/index.css';
+import './main.css';
+
+const container = document.getElementById('root') as HTMLDivElement;
+if (container) {
+    init(container, {
+        manifestUri: 'https://wellcomelibrary.org/iiif/b18035723/manifest',
+    })
+}

--- a/npm-examples/esbuild/src/main.css
+++ b/npm-examples/esbuild/src/main.css
@@ -1,0 +1,9 @@
+html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+.uv {
+    height: 100%;
+}

--- a/npm-examples/react-scripts/.gitignore
+++ b/npm-examples/react-scripts/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+package-lock.json
+yarn.lock

--- a/npm-examples/react-scripts/package.json
+++ b/npm-examples/react-scripts/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "react",
+  "version": "1.0.0",
+  "description": "React example starter project",
+  "keywords": [
+    "react",
+    "starter"
+  ],
+  "main": "src/index.js",
+  "dependencies": {
+    "@google/model-viewer": "0.7.2",
+    "babel-jest": "^26.6.3",
+    "jquery": "^3.6.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "react-scripts": "4.0.0",
+    "universalviewer": "../../"
+  },
+  "devDependencies": {
+    "@babel/runtime": "7.13.8",
+    "typescript": "4.1.3"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
+}

--- a/npm-examples/react-scripts/public/index.html
+++ b/npm-examples/react-scripts/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/npm-examples/react-scripts/src/style.css
+++ b/npm-examples/react-scripts/src/style.css
@@ -1,0 +1,4 @@
+html, body {
+    margin: 0;
+    padding: 0;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -365,6 +365,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA=="
+    },
     "@types/eslint": {
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
@@ -437,6 +442,11 @@
       "requires": {
         "jszip": "*"
       }
+    },
+    "@types/less": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/less/-/less-3.0.3.tgz",
+      "integrity": "sha512-1YXyYH83h6We1djyoUEqTlVyQtCfJAFXELSKW2ZRtjHD4hQ82CC4lvrv5D0l0FLcKBaiPbXyi3MpMsI9ZRgKsw=="
     },
     "@types/localforage": {
       "version": "0.0.34",
@@ -797,6 +807,11 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -1565,8 +1580,7 @@
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "base": {
       "version": "0.11.2",
@@ -1740,14 +1754,12 @@
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2035,10 +2047,9 @@
       }
     },
     "clean-css": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
-      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
-      "dev": true,
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz",
+      "integrity": "sha512-/eR8ru5zyxKzpBLv9YZvMXgTSSQn7AdkMItMYynsFgGwTveCRVam9IUPFloE85B4vAIj05IuKmmEoV7/AQjT0w==",
       "requires": {
         "source-map": "~0.6.0"
       }
@@ -2208,8 +2219,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -2269,7 +2279,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.3.tgz",
       "integrity": "sha512-GK6QUtisv4fNS+XcI7shX0Gx9ORg7QqIznyfho79JTnX1XhLiyZHfftvGiziqzRiEi/Bjhgpi+D2o7HxJFPnDQ==",
-      "dev": true,
       "requires": {
         "is-what": "^3.12.0"
       }
@@ -2333,6 +2342,125 @@
           "requires": {
             "yocto-queue": "^0.1.0"
           }
+        }
+      }
+    },
+    "copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "requires": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
     },
@@ -2405,7 +2533,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
       "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0",
         "css-what": "^5.0.0",
@@ -2414,11 +2541,19 @@
         "nth-check": "^2.0.0"
       }
     },
+    "css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "requires": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      }
+    },
     "css-what": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
-      "dev": true
+      "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -2429,6 +2564,14 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
       "integrity": "sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4="
+    },
+    "csso": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
+      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
+      "requires": {
+        "css-tree": "^1.1.2"
+      }
     },
     "cssom": {
       "version": "0.3.8",
@@ -2874,7 +3017,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
       "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -2889,8 +3031,7 @@
     "domelementtype": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -2913,7 +3054,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
       "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.2.0"
       }
@@ -2922,7 +3062,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -2981,6 +3120,11 @@
       "integrity": "sha512-iwIP/6WoeSimzUKJIQtjtpVDsK8Ir8qQCMXsUBwg+rxJR2Uh3wTNSbxoYRfs+3UWx/9MAnPIxVZCyWkm8MT0uw==",
       "dev": true
     },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
@@ -3014,8 +3158,7 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "envinfo": {
       "version": "7.8.1",
@@ -3027,7 +3170,6 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.8.tgz",
       "integrity": "sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==",
-      "dev": true,
       "optional": true,
       "requires": {
         "prr": "~1.0.1"
@@ -3131,11 +3273,153 @@
         "ext": "^1.1.2"
       }
     },
+    "esbuild": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.12.tgz",
+      "integrity": "sha512-vTKKUt+yoz61U/BbrnmlG9XIjwpdIxmHB8DlPR0AAW6OdS+nBQBci6LUHU2q9WbBobMEIQxxDpKbkmOGYvxsow==",
+      "requires": {
+        "esbuild-android-arm64": "0.13.12",
+        "esbuild-darwin-64": "0.13.12",
+        "esbuild-darwin-arm64": "0.13.12",
+        "esbuild-freebsd-64": "0.13.12",
+        "esbuild-freebsd-arm64": "0.13.12",
+        "esbuild-linux-32": "0.13.12",
+        "esbuild-linux-64": "0.13.12",
+        "esbuild-linux-arm": "0.13.12",
+        "esbuild-linux-arm64": "0.13.12",
+        "esbuild-linux-mips64le": "0.13.12",
+        "esbuild-linux-ppc64le": "0.13.12",
+        "esbuild-netbsd-64": "0.13.12",
+        "esbuild-openbsd-64": "0.13.12",
+        "esbuild-sunos-64": "0.13.12",
+        "esbuild-windows-32": "0.13.12",
+        "esbuild-windows-64": "0.13.12",
+        "esbuild-windows-arm64": "0.13.12"
+      }
+    },
+    "esbuild-android-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.12.tgz",
+      "integrity": "sha512-TSVZVrb4EIXz6KaYjXfTzPyyRpXV5zgYIADXtQsIenjZ78myvDGaPi11o4ZSaHIwFHsuwkB6ne5SZRBwAQ7maw==",
+      "optional": true
+    },
+    "esbuild-darwin-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.12.tgz",
+      "integrity": "sha512-c51C+N+UHySoV2lgfWSwwmlnLnL0JWj/LzuZt9Ltk9ub1s2Y8cr6SQV5W3mqVH1egUceew6KZ8GyI4nwu+fhsw==",
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.12.tgz",
+      "integrity": "sha512-JvAMtshP45Hd8A8wOzjkY1xAnTKTYuP/QUaKp5eUQGX+76GIie3fCdUUr2ZEKdvpSImNqxiZSIMziEiGB5oUmQ==",
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.12.tgz",
+      "integrity": "sha512-r6On/Skv9f0ZjTu6PW5o7pdXr8aOgtFOEURJZYf1XAJs0IQ+gW+o1DzXjVkIoT+n1cm3N/t1KRJfX71MPg/ZUA==",
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.12.tgz",
+      "integrity": "sha512-F6LmI2Q1gii073kmBE3NOTt/6zLL5zvZsxNLF8PMAwdHc+iBhD1vzfI8uQZMJA1IgXa3ocr3L3DJH9fLGXy6Yw==",
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.12.tgz",
+      "integrity": "sha512-U1UZwG3UIwF7/V4tCVAo/nkBV9ag5KJiJTt+gaCmLVWH3bPLX7y+fNlhIWZy8raTMnXhMKfaTvWZ9TtmXzvkuQ==",
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.12.tgz",
+      "integrity": "sha512-YpXSwtu2NxN3N4ifJxEdsgd6Q5d8LYqskrAwjmoCT6yQnEHJSF5uWcxv783HWN7lnGpJi9KUtDvYsnMdyGw71Q==",
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.12.tgz",
+      "integrity": "sha512-SyiT/JKxU6J+DY2qUiSLZJqCAftIt3uoGejZ0HDnUM2MGJqEGSGh7p1ecVL2gna3PxS4P+j6WAehCwgkBPXNIw==",
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.12.tgz",
+      "integrity": "sha512-sgDNb8kb3BVodtAlcFGgwk+43KFCYjnFOaOfJibXnnIojNWuJHpL6aQJ4mumzNWw8Rt1xEtDQyuGK9f+Y24jGA==",
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.12.tgz",
+      "integrity": "sha512-qQJHlZBG+QwVIA8AbTEtbvF084QgDi4DaUsUnA+EolY1bxrG+UyOuGflM2ZritGhfS/k7THFjJbjH2wIeoKA2g==",
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.12.tgz",
+      "integrity": "sha512-2dSnm1ldL7Lppwlo04CGQUpwNn5hGqXI38OzaoPOkRsBRWFBozyGxTFSee/zHFS+Pdh3b28JJbRK3owrrRgWNw==",
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.12.tgz",
+      "integrity": "sha512-D4raxr02dcRiQNbxOLzpqBzcJNFAdsDNxjUbKkDMZBkL54Z0vZh4LRndycdZAMcIdizC/l/Yp/ZsBdAFxc5nbA==",
+      "optional": true
+    },
+    "esbuild-openbsd-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.12.tgz",
+      "integrity": "sha512-KuLCmYMb2kh05QuPJ+va60bKIH5wHL8ypDkmpy47lzwmdxNsuySeCMHuTv5o2Af1RUn5KLO5ZxaZeq4GEY7DaQ==",
+      "optional": true
+    },
+    "esbuild-plugin-less": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-less/-/esbuild-plugin-less-1.1.5.tgz",
+      "integrity": "sha512-Dj8zYnnZwH+NoQ/RlvWyos7AA9MpTpUFriorAeEUy5sw4jZvPQn9y+SlBFnP1BFOLuS+xdVPUdOwQiS4MW6uQw==",
+      "requires": {
+        "@types/less": "^3.0.3",
+        "less": "^4.1.1"
+      }
+    },
+    "esbuild-plugin-svg": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-svg/-/esbuild-plugin-svg-0.1.0.tgz",
+      "integrity": "sha512-/9ZhvIpl+Ovl6glVK3BedvIwrOwSQnECw4Fy6ZwysWib3Ns7UkX6WNGjMOWtvQ1Cnm0uc7sptiKGm0BthKCAJA==",
+      "requires": {
+        "svgo": "^2.2.2"
+      }
+    },
+    "esbuild-sunos-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.12.tgz",
+      "integrity": "sha512-jBsF+e0woK3miKI8ufGWKG3o3rY9DpHvCVRn5eburMIIE+2c+y3IZ1srsthKyKI6kkXLvV4Cf/E7w56kLipMXw==",
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.12.tgz",
+      "integrity": "sha512-L9m4lLFQrFeR7F+eLZXG82SbXZfUhyfu6CexZEil6vm+lc7GDCE0Q8DiNutkpzjv1+RAbIGVva9muItQ7HVTkQ==",
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.12.tgz",
+      "integrity": "sha512-k4tX4uJlSbSkfs78W5d9+I9gpd+7N95W7H2bgOMFPsYREVJs31+Q2gLLHlsnlY95zBoPQMIzHooUIsixQIBjaQ==",
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.13.12",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.12.tgz",
+      "integrity": "sha512-2tTv/BpYRIvuwHpp2M960nG7uvL+d78LFW/ikPItO+2GfK51CswIKSetSpDii+cjz8e9iSPgs+BU4o8nWICBwQ==",
+      "optional": true
+    },
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -3931,8 +4215,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.13",
@@ -4017,7 +4300,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4148,8 +4430,12 @@
     "graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
-      "dev": true
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growly": {
       "version": "1.3.0",
@@ -4394,6 +4680,15 @@
         "terser": "^4.6.3"
       },
       "dependencies": {
+        "clean-css": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+          "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.6.0"
+          }
+        },
         "commander": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -4600,7 +4895,6 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -4620,7 +4914,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
-      "dev": true,
       "optional": true
     },
     "immediate": {
@@ -4662,7 +4955,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -5148,8 +5440,7 @@
     "is-what": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
-      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
-      "dev": true
+      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -6469,7 +6760,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.2.tgz",
       "integrity": "sha512-EoQp/Et7OSOVu0aJknJOtlXZsnr8XE8KwuzTHOLeVSEx8pVWUICc8Q0VYRHgzyjX78nMEyC/oztWFbgyhtNfDA==",
-      "dev": true,
       "requires": {
         "copy-anything": "^2.0.1",
         "errno": "^0.1.1",
@@ -6486,8 +6776,7 @@
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
-          "dev": true
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -6498,6 +6787,41 @@
       "dev": true,
       "requires": {
         "klona": "^2.0.4"
+      }
+    },
+    "less-plugin-clean-css": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/less-plugin-clean-css/-/less-plugin-clean-css-1.5.1.tgz",
+      "integrity": "sha1-zFeveqM5iVflbezr5jy2DCNClwM=",
+      "requires": {
+        "clean-css": "^3.0.1"
+      },
+      "dependencies": {
+        "clean-css": {
+          "version": "3.4.28",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
+          "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+          "requires": {
+            "commander": "2.8.x",
+            "source-map": "0.4.x"
+          }
+        },
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
       }
     },
     "leven": {
@@ -6631,7 +6955,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
       "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
       "optional": true,
       "requires": {
         "pify": "^4.0.1",
@@ -6642,14 +6965,12 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true,
           "optional": true
         }
       }
@@ -6715,6 +7036,11 @@
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
       "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
       "dev": true
+    },
+    "mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -6827,8 +7153,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "dev": true
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.50.0",
@@ -6867,7 +7192,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -7024,7 +7348,6 @@
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
       "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
-      "dev": true,
       "optional": true,
       "requires": {
         "debug": "^3.2.6",
@@ -7036,7 +7359,6 @@
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
           "optional": true,
           "requires": {
             "ms": "^2.1.1"
@@ -7046,14 +7368,12 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-          "dev": true,
           "optional": true
         }
       }
@@ -7160,6 +7480,38 @@
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
       "dev": true
     },
+    "noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -7210,7 +7562,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
       "integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
-      "dev": true,
       "requires": {
         "boolbase": "^1.0.0"
       }
@@ -7380,7 +7731,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -7598,8 +7948,7 @@
     "parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
-      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==",
-      "dev": true
+      "integrity": "sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA=="
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -7652,8 +8001,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -8069,7 +8417,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true,
       "optional": true
     },
     "pseudomap": {
@@ -8752,8 +9099,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-main-filename": {
       "version": "1.0.1",
@@ -8897,8 +9243,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sane": {
       "version": "2.5.2",
@@ -9593,8 +9938,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-js": {
       "version": "0.6.2",
@@ -9782,6 +10126,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
+    },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
     "stack-utils": {
       "version": "1.0.5",
@@ -9975,6 +10324,27 @@
       "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
       "dev": true
     },
+    "svgo": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
+      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
+      "requires": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^4.1.3",
+        "css-tree": "^1.1.3",
+        "csso": "^4.2.0",
+        "picocolors": "^1.0.0",
+        "stable": "^0.1.8"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        }
+      }
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -10103,6 +10473,15 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
     },
     "thunky": {
       "version": "1.1.0",
@@ -10743,6 +11122,11 @@
           "dev": true
         }
       }
+    },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
     },
     "uri-js": {
       "version": "4.4.1",
@@ -11725,8 +12109,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.4.3",
@@ -11767,6 +12150,11 @@
         "commander": "^2.9.0",
         "cssfilter": "0.0.10"
       }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "webpack-helpers.js"
   ],
   "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "typings": "dist/cjs/index.d.ts",
   "web": "dist/umd/UV.js",
   "scripts": {
@@ -18,9 +19,11 @@
     "lint": "prettier --write \"./src/**/*.{js,jsx,json,css,ts,tsx}\"",
     "start": "npx webpack serve -c webpack.dev-server.js",
     "build": "webpack -c webpack.config.js",
-    "build-tsc": "tsc --skipLibCheck --outDir ./dist/cjs -p . ",
+    "build-es": "node ./esbuild.mjs",
+    "build-tsc": "tsc --skipLibCheck --declarationDir ./dist/cjs --declaration --outDir ./dist/cjs -p . && npm run copy-files",
+    "copy-files": "copyfiles -u 1 src/**/*.svg dist/cjs && copyfiles -u 1 src/**/*.gif dist/cjs && copyfiles -u 1 src/**/*.less dist/cjs && copyfiles -u 1 src/extensions/**/*.less dist/cjs && copyfiles -u 1 src/**/*.css dist/cjs",
     "test": "jest",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build && npm run build-tsc && npm run build-es"
   },
   "repository": {
     "type": "git",
@@ -89,8 +92,14 @@
     "@universalviewer/aleph": "0.0.15",
     "@universalviewer/uv-ebook-components": "1.0.2",
     "@webcomponents/webcomponentsjs": "^2.4.3",
+    "clean-css": "^5.2.2",
+    "copyfiles": "^2.4.1",
+    "esbuild": "^0.13.12",
+    "esbuild-plugin-less": "^1.1.5",
+    "esbuild-plugin-svg": "^0.1.0",
     "jquery": "3.5.0",
     "jsviews": "0.9.83",
+    "less-plugin-clean-css": "^1.5.1",
     "manifesto.js": "4.2.4",
     "mediaelement": "4.2.15",
     "mediaelement-plugins": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "npx webpack serve -c webpack.dev-server.js",
     "build": "webpack -c webpack.config.js",
     "build-es": "node ./esbuild.mjs",
-    "build-tsc": "tsc --skipLibCheck --declarationDir ./dist/cjs --declaration --outDir ./dist/cjs -p . && npm run copy-files",
+    "build-tsc": "tsc --skipLibCheck --module CommonJS --esModuleInterop --declarationDir ./dist/cjs --declaration --outDir ./dist/cjs -p . && npm run copy-files",
     "copy-files": "copyfiles -u 1 src/**/*.svg dist/cjs && copyfiles -u 1 src/**/*.gif dist/cjs && copyfiles -u 1 src/**/*.less dist/cjs && copyfiles -u 1 src/extensions/**/*.less dist/cjs && copyfiles -u 1 src/**/*.css dist/cjs",
     "test": "jest",
     "prepublishOnly": "npm run build && npm run build-tsc && npm run build-es"

--- a/src/UniversalViewer.ts
+++ b/src/UniversalViewer.ts
@@ -43,6 +43,7 @@ export class UniversalViewer extends BaseComponent implements IUVComponent {
   public extension: IExtension | null;
   public isFullScreen: boolean = false;
   public adaptor: IUVAdaptor;
+  public disposed = false;
 
   constructor(options: IBaseComponentOptions) {
     super(options);
@@ -161,8 +162,19 @@ export class UniversalViewer extends BaseComponent implements IUVComponent {
     this._pubsub.publish(event, args);
   }
 
-  public subscribe(event: string, cb: any): void {
+  public subscribe(event: string, cb: any) {
     this._pubsub.subscribe(event, cb);
+
+    return () => {
+      this._pubsub.unsubscribe(event, cb);
+    }
+  }
+
+  public dispose() {
+    this._pubsub.dispose();
+    this.disposed = true;
+    const $elem: JQuery = $(this.options.target);
+    $elem.empty();
   }
 
   private async _reload(data: IUVData): Promise<void> {
@@ -318,6 +330,7 @@ export class UniversalViewer extends BaseComponent implements IUVComponent {
       this.extension.data = data;
       this.extension.helper = helper;
       this.extension.create();
+      this.el.classList.add(extension.name)
     }
   }
 
@@ -328,7 +341,7 @@ export class UniversalViewer extends BaseComponent implements IUVComponent {
   }
 
   public resize(): void {
-    if (this.extension) {
+    if (this.extension && !this.disposed) {
       this.extension.resize();
     }
   }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -27,7 +27,7 @@ export const isValidUrl = (value: string): boolean => {
 
 export const debounce = (callback: (args: any) => void, wait: number) => {
   let timeout;
-  return (...args) => {
+  return function (...args) {
     const context = this;
     clearTimeout(timeout);
     timeout = setTimeout(() => callback.apply(context, args), wait);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import './shim-jquery';
+
 export { URLAdaptor } from "./URLAdaptor";
 export { UniversalViewer as Viewer } from "./UniversalViewer";
+export { BaseEvents } from "./modules/uv-shared-module/BaseEvents";
 export { init } from "./Init";

--- a/src/modules/uv-modelviewercenterpanel-module/ModelViewerCenterPanel.ts
+++ b/src/modules/uv-modelviewercenterpanel-module/ModelViewerCenterPanel.ts
@@ -1,6 +1,6 @@
 const $ = require("jquery");
 import "@webcomponents/webcomponentsjs/webcomponents-bundle.js";
-import "../../../node_modules/@google/model-viewer/dist/model-viewer-legacy";
+import "@google/model-viewer/dist/model-viewer-legacy";
 import { AnnotationBody, Canvas, IExternalResource } from "manifesto.js";
 import { sanitize, debounce } from "../../Utils";
 import { BaseEvents } from "../uv-shared-module/BaseEvents";

--- a/src/modules/uv-pdfcenterpanel-module/css/styles.less
+++ b/src/modules/uv-pdfcenterpanel-module/css/styles.less
@@ -1,4 +1,4 @@
-.uv {
+.uv-extension-host.uv-pdf-extension {
 
     .centerPanel {
 

--- a/src/modules/uv-slideatlascenterpanel-module/css/styles.less
+++ b/src/modules/uv-slideatlascenterpanel-module/css/styles.less
@@ -1,4 +1,4 @@
-.uv {
+.uv-extension-host.uv-slideatlas-extension {
   .centerPanel {
     @img-path: "../../../modules/uv-slideatlascenterpanel-module/img/";
 

--- a/src/shim-jquery.ts
+++ b/src/shim-jquery.ts
@@ -1,0 +1,3 @@
+import $ from 'jquery';
+window.$ = $;
+window.jQuery = $;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
       "@iiif/base-component",
       "jest",
       "jquery",
-      "node",
+      "node"
     ]
   },
   "exclude": [


### PR DESCRIPTION
This PR adds in a few package publishing options, and a way to test them (before publishing to NPM)

The package.json for publishing looks like this:
```json
{
  "main": "dist/cjs/index.js",
  "module": "dist/esm/index.js",
  "typings": "dist/cjs/index.d.ts",
  "web": "dist/umd/UV.js"
}
```

* `main` - this is what some bundlers will go for, and typically expect node-like imports (require) and don't have lazy loading included. The CJS folder contains all of the individual files (from typescript compiler)
* `module` - this is used by more modern bundlers (recent webpack, esbuild etc.) and has module import/export. This is code-split similar to the webpack bundle, but is aimed at bundlers themselves (or modern browsers)
* `typings` - this will offer type-assistance for anyone importing in Typescript and Javascript in most IDEs
* `web` - this will be served by CDNs and some other bundlers, like snowpack, as a standalone bundle


## Integrations
This enables some integrations, and improves some others. There are some problems, but they can be addressed later.

### Using with a bundler
When using in your own webpack bundler, you can import the init normally, and grab the pre-bundled CSS file.

```js
import { init } from 'universalviewer';
import 'universalviewer/dist/esm/index.css';

init( ... )
```

### Using in browser
If you have a modern browser, you can import the UV directly, no bundler required. This is a good test, as if it works using the browser module loader, it's likely to work with most other bundlers.

```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <title>UV Frontend</title>
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/universalviewer@4.0.0/dist/esm/index.css" />
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/universalviewer@4.0.0/dist/uv.css" />
    <style> body, html { margin: 0; padding: 0; height: 100%; }</style>
</head>
<body>
<div class="uv" id="root"></div>

<script type="module">

    import { init } from 'https://cdn.jsdelivr.net/npm/universalviewer@4.0.0/dist/esm/index.js';

    init(document.getElementById('root'), {
        manifestUri: 'https://wellcomelibrary.org/iiif/b18035723/manifest',
    });

</script>
</body>
</html>
```
(Note: 4.0.0 tag does not exist yet)

This is maybe good for hacking with the UV, and then published with the webpack bundle from a CDN or packaged into a bundler.

### With typescript

If you import the UV in typescript, or in an editor like VSCode, you will get type assistance.

<img width="447" alt="Screenshot 2021-11-03 at 00 32 20" src="https://user-images.githubusercontent.com/8266711/139969830-e0eaa3dd-ec09-44b8-b7ac-9840e0de44be.png">


### CSS Size
This is a more general issue, but is clearer to see when the CSS is bundled together. There is a lot of inline images, some duplicates like the spinning gif, that could be optimised. The CSS bundle sits around ~1.3Mb at the moment. 


### NPM Examples

I've added a new folder `npm-examples` that contain mini-projects. Although they _could_ be used as examples, they are more aimed at testing NPM integrations without publishing. In the `package.json` of these examples, the UV is defined as:
```json
{
    "dependencies": {
        "universalviewer": "../../"
    }
}
```
This means we can test for regressions in bundlers and module loading - or add new examples. They can also be useful for other testing. In the react example I added mounting and unmounting of multiple UVs on a single page. 

Each of the examples should be accessible (after running `npm run prepublishOnly` in the root) by simply running an npm install and then npm start.