### PR TITLE
Fixed loading images into UV

### DIFF
--- a/src/UniversalViewer.ts
+++ b/src/UniversalViewer.ts
@@ -162,6 +162,10 @@ export class UniversalViewer extends BaseComponent implements IExtensionHost {
   }
 
   private _getExtensionByFormat(format: string): any {
+    if (format.startsWith('image/')) {
+      format = 'image';
+    }
+
     if (!this._extensionRegistry[format]) {
       return this._getExtensionByType(Extension.DEFAULT, format);
     }


### PR DESCRIPTION
The registry has a mapping for `image`
<img width="450" alt="Screenshot 2022-02-20 at 17 58 20" src="https://user-images.githubusercontent.com/8266711/154856836-d6c97efd-5a5e-4b01-bf66-bc2c312dbdbf.png">

But this fails for image formats, since they typically appear as `image/jpg` or `image/png`. There is a separate `image/jpeg` definition, which could also be removed. This should catch images of any format.