### PR TITLE
Dev tools

### DIFF
--- a/src/DevTools.ts
+++ b/src/DevTools.ts
@@ -1,0 +1,78 @@
+import {UniversalViewer} from "./UniversalViewer";
+import {BaseEvents} from "./modules/uv-shared-module/BaseEvents";
+
+export class DevTools {
+  element: HTMLElement;
+  uv: UniversalViewer;
+  log: HTMLTextAreaElement;
+  buttonContainer: HTMLDivElement;
+  buttons: Record<string, HTMLButtonElement>;
+  logging = false;
+  originalLogger: any;
+
+  constructor(element: HTMLElement, uv: UniversalViewer) {
+    this.element = element;
+    this.uv = uv;
+
+
+    const title = document.createElement('h2');
+    title.innerText = 'dev tools';
+    this.element.append(title);
+    this.log = document.createElement('textarea');
+    this.log.rows = 20;
+    this.log.disabled = true;
+    this.log.wrap = 'soft';
+    this.element.style.display = 'block';
+    this.element.style.clear = 'both';
+    this.log.style.whiteSpace = 'no-wrap';
+    this.log.style.overflowX = 'scroll';
+    this.log.style.whiteSpace = 'pre';
+    this.log.style.width = '100%';
+    this.element.append(this.log);
+
+    this.buttons = {};
+    this.buttonContainer = document.createElement('div');
+    this.element.append(this.buttonContainer);
+
+    this.createButton('Clear log', () => {
+      this.log.value = '';
+    })
+
+    const jsonStringify = (j: any) => {
+      try {
+        return JSON.stringify(j);
+      } catch (e) {
+        return `${j}`;
+      }
+    }
+
+    this.originalLogger = console.log.bind(console);
+    console.log = (...input: any[]) => {
+      this.log.value = this.log.value += input ? `\nconsole.log(${input.map(v => jsonStringify(v)).join(', ')})` : ``;
+      this.log.scrollTop = this.log.scrollHeight;
+      this.originalLogger(...input)
+    }
+
+    for (const ev of Object.keys(BaseEvents)) {
+      const event = BaseEvents[ev];
+      this.uv.on(event, (e, ...rest) => {
+        this.log.value = this.log.value += e ? `\n${ev}(${jsonStringify(e)})` : `\n${ev}`;
+        this.log.scrollTop = this.log.scrollHeight;
+        if (this.logging) {
+          this.originalLogger(ev, e, ...rest);
+        }
+      }, {})
+    }
+    this.uv.on(BaseEvents.CANVAS_INDEX_CHANGE, (ev) => {
+      console.log(ev);
+    }, {})
+
+  }
+
+  createButton(name: string, onClick: (e: MouseEvent) => void) {
+    this.buttons[name] = document.createElement('button');
+    this.buttons[name].innerText = name;
+    this.buttons[name].addEventListener('click', onClick);
+    this.buttonContainer.append(this.buttons[name]);
+  }
+}

--- a/src/DevTools.ts
+++ b/src/DevTools.ts
@@ -1,5 +1,5 @@
-import {UniversalViewer} from "./UniversalViewer";
-import {IIIFEvents} from "@/content-handlers/iiif/IIIFEvents";
+import { UniversalViewer } from "./UniversalViewer";
+import { IIIFEvents } from "./content-handlers/iiif/IIIFEvents";
 
 export class DevTools {
   element: HTMLElement;
@@ -14,29 +14,28 @@ export class DevTools {
     this.element = element;
     this.uv = uv;
 
-
-    const title = document.createElement('h2');
-    title.innerText = 'dev tools';
+    const title = document.createElement("h2");
+    title.innerText = "dev tools";
     this.element.append(title);
-    this.log = document.createElement('textarea');
+    this.log = document.createElement("textarea");
     this.log.rows = 20;
     this.log.disabled = true;
-    this.log.wrap = 'soft';
-    this.element.style.display = 'block';
-    this.element.style.clear = 'both';
-    this.log.style.whiteSpace = 'no-wrap';
-    this.log.style.overflowX = 'scroll';
-    this.log.style.whiteSpace = 'pre';
-    this.log.style.width = '100%';
+    this.log.wrap = "soft";
+    this.element.style.display = "block";
+    this.element.style.clear = "both";
+    this.log.style.whiteSpace = "no-wrap";
+    this.log.style.overflowX = "scroll";
+    this.log.style.whiteSpace = "pre";
+    this.log.style.width = "100%";
     this.element.append(this.log);
 
     this.buttons = {};
-    this.buttonContainer = document.createElement('div');
+    this.buttonContainer = document.createElement("div");
     this.element.append(this.buttonContainer);
 
-    this.createButton('Clear log', () => {
-      this.log.value = '';
-    })
+    this.createButton("Clear log", () => {
+      this.log.value = "";
+    });
 
     const jsonStringify = (j: any) => {
       try {
@@ -44,35 +43,46 @@ export class DevTools {
       } catch (e) {
         return `${j}`;
       }
-    }
+    };
 
     this.originalLogger = console.log.bind(console);
     console.log = (...input: any[]) => {
-      this.log.value = this.log.value += input ? `\nconsole.log(${input.map(v => jsonStringify(v)).join(', ')})` : ``;
+      this.log.value = this.log.value += input
+        ? `\nconsole.log(${input.map(v => jsonStringify(v)).join(", ")})`
+        : ``;
       this.log.scrollTop = this.log.scrollHeight;
-      this.originalLogger(...input)
-    }
+      this.originalLogger(...input);
+    };
 
     for (const ev of Object.keys(IIIFEvents)) {
       const event = IIIFEvents[ev];
-      this.uv.on(event, (e, ...rest) => {
-        this.log.value = this.log.value += e ? `\n${ev}(${jsonStringify(e)})` : `\n${ev}`;
-        this.log.scrollTop = this.log.scrollHeight;
-        if (this.logging) {
-          this.originalLogger(ev, e, ...rest);
-        }
-      }, {})
+      this.uv.on(
+        event,
+        (e, ...rest) => {
+          this.log.value = this.log.value += e
+            ? `\n${ev}(${jsonStringify(e)})`
+            : `\n${ev}`;
+          this.log.scrollTop = this.log.scrollHeight;
+          if (this.logging) {
+            this.originalLogger(ev, e, ...rest);
+          }
+        },
+        {}
+      );
     }
-    this.uv.on(IIIFEvents.CANVAS_INDEX_CHANGE, (ev) => {
-      console.log(ev);
-    }, {})
-
+    this.uv.on(
+      IIIFEvents.CANVAS_INDEX_CHANGE,
+      ev => {
+        console.log(ev);
+      },
+      {}
+    );
   }
 
   createButton(name: string, onClick: (e: MouseEvent) => void) {
-    this.buttons[name] = document.createElement('button');
+    this.buttons[name] = document.createElement("button");
     this.buttons[name].innerText = name;
-    this.buttons[name].addEventListener('click', onClick);
+    this.buttons[name].addEventListener("click", onClick);
     this.buttonContainer.append(this.buttons[name]);
   }
 }

--- a/src/DevTools.ts
+++ b/src/DevTools.ts
@@ -1,5 +1,5 @@
 import {UniversalViewer} from "./UniversalViewer";
-import {BaseEvents} from "./modules/uv-shared-module/BaseEvents";
+import {IIIFEvents} from "@/content-handlers/iiif/IIIFEvents";
 
 export class DevTools {
   element: HTMLElement;
@@ -53,8 +53,8 @@ export class DevTools {
       this.originalLogger(...input)
     }
 
-    for (const ev of Object.keys(BaseEvents)) {
-      const event = BaseEvents[ev];
+    for (const ev of Object.keys(IIIFEvents)) {
+      const event = IIIFEvents[ev];
       this.uv.on(event, (e, ...rest) => {
         this.log.value = this.log.value += e ? `\n${ev}(${jsonStringify(e)})` : `\n${ev}`;
         this.log.scrollTop = this.log.scrollHeight;
@@ -63,7 +63,7 @@ export class DevTools {
         }
       }, {})
     }
-    this.uv.on(BaseEvents.CANVAS_INDEX_CHANGE, (ev) => {
+    this.uv.on(IIIFEvents.CANVAS_INDEX_CHANGE, (ev) => {
       console.log(ev);
     }, {})
 

--- a/src/index.html
+++ b/src/index.html
@@ -170,6 +170,10 @@
       </div>
     </div>
 
+      <div id="dev">
+
+      </div>
+
     <script type="text/javascript">
       function createOptGroup(label) {
         var optGroup = document.createElement("optgroup");
@@ -442,6 +446,8 @@
           // };
 
           uv = UV.init("uv", data);
+
+          const devtools = new UV.DevTools(document.getElementById('dev'), uv)
 
           //console.log(UV.init, UV.IIIFURLAdapter, UV.BaseEvents);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { UniversalViewer as Viewer } from "./UniversalViewer";
 export { Events } from "./Events";
 export { IIIFEvents } from "./content-handlers/iiif/IIIFEvents";
 export { init } from "./Init";
+export { DevTools } from './DevTools';


### PR DESCRIPTION
Simple dev tools that can be optionally added to a page. Currently provides event logs (example in `src/index.html`)

**Other ideas for this:**
* Showing a detailed panel for the current helper (provided by Manifold)
  *  current canvas index
  * current canvas id
  * current manifest
  * etc..
* Deployment of custom events using dropdown (possibly JSON for args)
* Listing config resolved
* Listing components/extensions loaded (and config applied to each)

![Screenshot 2022-03-03 at 09 34 12](https://user-images.githubusercontent.com/8266711/156537377-7f14f340-2c57-4b37-bd79-053b12930c42.png)

