### PR TITLE
Fix search placemarker hover: use 'that' rather than 'this' when getting defaultLabel

### DIFF
--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -612,8 +612,8 @@ export class FooterPanel extends BaseFooterPanel {
       );
       let label: string | null = LanguageMap.getValue(canvas.getLabel());
 
-      if (!label && this.extension.helper.manifest) {
-        label = this.extension.helper.manifest.options.defaultLabel;
+      if (!label && that.extension.helper.manifest) {
+        label = that.extension.helper.manifest.options.defaultLabel;
       }
 
       if (label) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->
#### Fix placemarker hover on Search Footer when the canvas label is a blank:
Within searchfooterpanel extension, FooterPanel.ts incorrectly used `this.extensions` to access the default label when the label is blank in the manifest in `onPlacemarkerMouseEnter`.  `this` is not defined.

This PR updates `onPlacemarkerMouseEnter` to use `that` instead of `this`.

(Similar to PR merged for V3: https://github.com/UniversalViewer/universalviewer/pull/792)