### PR TITLE
Fix for dissapearing tree view after collapsing the left panel and re…

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -324,7 +324,6 @@ export class BaseExtension implements IExtension {
     });
 
     this.extensionHost.subscribe(IIIFEvents.CLOSE_RIGHT_PANEL, () => {
-      if (that.$element.hasClass("loading")) that.$element.removeClass("loading")
       this.resize();
     });
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -319,10 +319,12 @@ export class BaseExtension implements IExtension {
     );
 
     this.extensionHost.subscribe(IIIFEvents.CLOSE_LEFT_PANEL, () => {
+      if (that.$element.hasClass("loading")) that.$element.removeClass("loading")
       this.resize();
     });
 
     this.extensionHost.subscribe(IIIFEvents.CLOSE_RIGHT_PANEL, () => {
+      if (that.$element.hasClass("loading")) that.$element.removeClass("loading")
       this.resize();
     });
 


### PR DESCRIPTION
Fix for: https://github.com/UniversalViewer/universalviewer/issues/914

- This bug causes a serious issue in BL Sounds content as we were hoping to only have the Index view available yet currently switching between tabs is the most intuitive way of getting the tree view to re-appear.
- The event subscriber for opening the left hand panel is expecting that the css class "loading" is absent in all cases apart from the initial load. Yet the LOAD event subscriber which appears to be responsible for removing it doesn't get executed anymore ( I assume this is legacy code).
- Now we simply check for the existence of the the "loading" css class when the panel is closed and remove it if it is there. Therefore keeping the optimisation that limits the number of resize calls on the initial loading of UV.