### PR TITLE
fixes #913: Reinstate viewing properties on resources w/o service descriptor

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -27,7 +27,7 @@ import {
   IExternalResource,
   IExternalResourceData,
   IExternalResourceOptions,
-  // IExternalImageResourceData,
+  IExternalImageResourceData,
   IManifestoOptions,
   Manifest,
   Range,
@@ -968,11 +968,11 @@ export class BaseExtension implements IExtension {
     resource.data.hasServiceDescriptor = resource.hasServiceDescriptor();
 
     // if the data isn't an info.json, give it the necessary viewing properties
-    // if (!resource.hasServiceDescriptor()) {
-    //   resource.data.id = <string>resource.dataUri;
-    //   (<IExternalImageResourceData>resource.data).width = resource.width;
-    //   (<IExternalImageResourceData>resource.data).height = resource.height;
-    // }
+    if (!resource.hasServiceDescriptor()) {
+      resource.data.id = <string>resource.dataUri;
+      (<IExternalImageResourceData>resource.data).width = resource.width;
+      (<IExternalImageResourceData>resource.data).height = resource.height;
+    }
 
     resource.data.index = resource.index;
 


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

This PR fixes a bug causing the main image from being loaded under certain circumstances (described in #913). The bug appears to have been introduced in 3a01c62 (originally implemented to fix #817), where the lines restored in this PR were commented out. It is unclear to me why it was necessary to comment these lines out, but I have confirmed that UV works in this branch with the following manifests:

- https://api.cultural.jp/iiif/britishm-776876/manifest (reported as not working in #913)
- https://lbiiif.riksarkivet.se/arkis!00147269/manifest (reported as not working in #817 and fixed in 3a01c62)
- https://iiif.io/api/cookbook/recipe/0005-image-service/ (reported as not working in #817 and fixed in 3a01c62)

As far as we can detect, the issue affects UV versions 4.0.11 and greater in an environment where we are not using an image service. I believe this issue has not been detected before because the examples in the wiki are pinned to older versions of UV (e.g. 4.0.0).

Fixes #913.

Please let me know if there is anything else we need to do in order to get this fix merged and released. I’ll be happy to make adjustments in the interest of getting this out there!