### PR TITLE
Extending the thumbnail label to reveal more text #758

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "universalviewer",
-  "version": "4.0.25",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "universalviewer",
-      "version": "4.0.25",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@edsilv/http-status-codes": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universalviewer",
-  "version": "4.0.25",
+  "version": "4.1.0",
   "description": "The Universal Viewer is a community-developed open source project on a mission to help you share your 📚📜📰📽️📻🗿 with the 🌎",
   "engines": {
     "node": ">=14.18.1",

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/GalleryView.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/GalleryView.ts
@@ -1,14 +1,15 @@
-const $ = require("jquery");
 import { IIIFEvents } from "../../IIIFEvents";
 import { ContentLeftPanel } from "../../extensions/config/ContentLeftPanel";
 import { BaseView } from "../uv-shared-module/BaseView";
 import { GalleryComponent } from "@iiif/iiif-gallery-component";
+import $ from "jquery"; 
 
 export class GalleryView extends BaseView<ContentLeftPanel> {
   isOpen: boolean = false;
   galleryComponent: any;
   galleryData: any;
   $gallery: JQuery;
+  $extendLabelsCheckbox: JQuery | undefined;
 
   constructor($element: JQuery) {
     super($element, true, true);
@@ -31,7 +32,7 @@ export class GalleryView extends BaseView<ContentLeftPanel> {
 
     this.galleryComponent.on(
       "thumbSelected",
-      function(thumb: any) {
+      function (thumb: any) {
         that.extensionHost.publish(IIIFEvents.GALLERY_THUMB_SELECTED, thumb);
         that.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
       },
@@ -40,7 +41,7 @@ export class GalleryView extends BaseView<ContentLeftPanel> {
 
     this.galleryComponent.on(
       "decreaseSize",
-      function() {
+      function () {
         that.extensionHost.publish(IIIFEvents.GALLERY_DECREASE_SIZE);
       },
       false
@@ -48,11 +49,30 @@ export class GalleryView extends BaseView<ContentLeftPanel> {
 
     this.galleryComponent.on(
       "increaseSize",
-      function() {
+      function () {
         that.extensionHost.publish(IIIFEvents.GALLERY_INCREASE_SIZE);
       },
       false
     );
+
+    setTimeout(() => {
+      const labelHasOverflow = this.checkLabelOverflow();
+
+      if (labelHasOverflow) {
+        this.$extendLabelsCheckbox = $('<input type="checkbox" id="extendLabelsCheckbox">');
+        const $label = $('<label for="extendLabelsCheckbox">Show full labels</label>');
+
+        this.$element.prepend($label);
+        this.$element.prepend(this.$extendLabelsCheckbox);
+
+        this.$extendLabelsCheckbox.on('change', () => {
+          const extendLabels = this.$extendLabelsCheckbox?.prop('checked');
+          if (extendLabels !== undefined) {
+            this.toggleLabelExtension(extendLabels);
+          }
+        });
+      }
+    }, 0);
   }
 
   public databind(): void {
@@ -65,7 +85,6 @@ export class GalleryView extends BaseView<ContentLeftPanel> {
     this.isOpen = true;
     this.$element.show();
 
-    // todo: would be better to have no imperative methods on components and use a reactive pattern
     setTimeout(() => {
       this.galleryComponent.selectIndex(this.extension.helper.canvasIndex);
     }, 10);
@@ -81,5 +100,34 @@ export class GalleryView extends BaseView<ContentLeftPanel> {
     const $main: JQuery = this.$gallery.find(".main");
     const $header: JQuery = this.$gallery.find(".header");
     $main.height(this.$element.height() - $header.height());
+  }
+
+  checkLabelOverflow(): boolean {
+    const $labels = this.$gallery.find('.info .label');
+    for (let i = 0; i < $labels.length; i++) {
+      const label = $labels[i];
+      if (label.scrollWidth > label.clientWidth) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  toggleLabelExtension(extendLabels: boolean): void {
+    if (extendLabels) {
+      this.$gallery.find('.info .label').css({
+        'overflow-x': 'visible',
+        'text-overflow': 'nowrap',
+        'white-space': 'break-spaces',
+        'max-width': '100%',
+      });
+    } else {
+      this.$gallery.find('.info .label').css({
+        'overflow-x': 'hidden',
+        'text-overflow': 'ellipsis',
+        'white-space': 'nowrap',
+        'max-width': '100%',
+      });
+    }
   }
 }

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Thumb } from "manifesto.js";
 import { ViewingDirection, ViewingHint } from "@iiif/vocabulary";
 import { useInView } from "react-intersection-observer";
@@ -50,7 +50,6 @@ const ThumbImage = ({
         {inView && <img src={thumb.uri} alt={thumb.label} />}
       </div>
       <div className="info">
-        {/* <span>{thumb.viewingHint}</span> */}
         <span className="label" title={thumb.label}>
           {thumb.label}&nbsp;
         </span>
@@ -76,14 +75,49 @@ const Thumbnails = ({
   viewingDirection: ViewingDirection;
 }) => {
   const ref = useRef<HTMLDivElement | null>(null);
+  const [extendLabels, setExtendLabels] = useState(false);
+  const [shouldShowCheckbox, setShouldShowCheckbox] = useState(false);
 
   useEffect(() => {
-    const thumb: HTMLElement = ref.current?.querySelector(`#thumb-${selected[0]}`) as HTMLElement;
+    const checkOverflow = () => {
+      if (ref.current) {
+        const thumbLabels = ref.current.querySelectorAll('.thumb .info .label');
+        let overflowDetected = false;
+  
+        thumbLabels.forEach((label) => {
+          if (label.scrollWidth > label.clientWidth) {
+            overflowDetected = true;
+            return;
+          }
+        });
+  
+        setShouldShowCheckbox(overflowDetected);
+      } else {
+        setShouldShowCheckbox(false);
+      }
+    };
+  
+    
+    checkOverflow();
+  
+    
+  
+    
+    return () => {
+      
+    };
+  }, [thumbs]);  
+  
+
+  useEffect(() => {
+    const thumb: HTMLElement = ref.current?.querySelector(
+      `#thumb-${selected[0]}`
+    ) as HTMLElement;
     const y: number = thumb?.offsetTop;
     ref.current?.parentElement!.scrollTo({
       top: y,
       left: 0,
-      behavior: 'smooth'
+      behavior: "smooth",
     });
   }, [selected]);
 
@@ -97,7 +131,6 @@ const Thumbnails = ({
     }
 
     if (paged) {
-      // if paged, show separator after every 2 thumbs
       return !((index - 1) % 2 === 0);
     }
 
@@ -109,29 +142,43 @@ const Thumbnails = ({
   });
 
   return (
-    <div
-      ref={ref}
-      className={cx("thumbs", {
-        "left-to-right": viewingDirection === ViewingDirection.LEFT_TO_RIGHT,
-        "right-to-left": viewingDirection === ViewingDirection.RIGHT_TO_LEFT,
-        paged: paged,
-      })}
-    >
-      {thumbs.map((thumb, index) => (
-        <span key={`thumb-${index}`} id={`thumb-${index}`}>
-          <ThumbImage
-            first={index === firstNonPagedIndex}
-            onClick={onClick}
-            paged={paged}
-            selected={selected.includes(index)}
-            thumb={thumb}
-            viewingDirection={viewingDirection}
+    <div>
+      {shouldShowCheckbox && (
+        <div>
+          <label htmlFor="extendLabelsCheckbox">Show full labels </label>
+          <input
+            type="checkbox"
+            id="extendLabelsCheckbox"
+            checked={extendLabels}
+            onChange={(e) => setExtendLabels(e.target.checked)}
           />
-          {showSeparator(paged, thumb.viewingHint, index) && (
-            <div className="separator"></div>
-          )}
-        </span>
-      ))}
+        </div>
+      )}
+      <div
+        ref={ref}
+        className={cx("thumbs", {
+          "extend-labels": extendLabels,
+          "left-to-right": viewingDirection === ViewingDirection.LEFT_TO_RIGHT,
+          "right-to-left": viewingDirection === ViewingDirection.RIGHT_TO_LEFT,
+          paged: paged,
+        })}
+      >
+        {thumbs.map((thumb, index) => (
+          <span key={`thumb-${index}`} id={`thumb-${index}`}>
+            <ThumbImage
+              first={index === firstNonPagedIndex}
+              onClick={onClick}
+              paged={paged}
+              selected={selected.includes(index)}
+              thumb={thumb}
+              viewingDirection={viewingDirection}
+            />
+            {showSeparator(paged, thumb.viewingHint, index) && (
+              <div className="separator"></div>
+            )}
+          </span>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/thumbs-view.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/thumbs-view.less
@@ -76,13 +76,24 @@
                 float: left;
             }
 
+           /* Default thumbnail label  */
             .thumbsView .thumbs .thumb .info .label {
                 float: left;
                 overflow-x: hidden;
                 text-overflow: ellipsis;
                 white-space: nowrap;
+                max-width: 100%;
+                
             }
-
+            
+            /* Extended label when checkbox is checked */
+            .thumbsView .thumbs.extend-labels .thumb .info .label {
+                overflow-x: visible;
+                text-overflow: nowrap;
+                white-space: break-spaces;
+                max-width: 100%;
+                
+            }
             .thumbsView .thumbs .thumb .info .searchResults {
                 float: right;
                 width: 35px;


### PR DESCRIPTION
Issue #758. Checkbox to extend label when there's text overflow in the thumbnail panel and gallery:

<img width="255" alt="Screenshot 2024-01-05 at 17 27 48" src="https://github.com/UniversalViewer/universalviewer/assets/139405429/eda03d77-d461-4b99-a929-14c8f965d218">

Doesn't show up if not needed: 
<img width="232" alt="Screenshot 2024-01-05 at 17 28 06" src="https://github.com/UniversalViewer/universalviewer/assets/139405429/becec801-fa04-4361-8593-80f5b32a7ee3">

