### PR TITLE
Fix format in wholeImageHighResLabel when using version 3 manifests

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -10,6 +10,7 @@ import {
   IExternalImageResourceData,
   Resource,
   Annotation,
+  AnnotationBody,
   ManifestResource,
   Rendering,
   LanguageMap,
@@ -264,11 +265,32 @@ const DownloadDialogue = ({
     return null;
   }
 
+  function getCanvasImageAnnotationBody(canvas: Canvas): AnnotationBody | null {
+    const images: Annotation[] = canvas.getContent();
+    if (images.length == 0) return null;
+
+    const bodies: AnnotationBody[] = images[0].getBody();
+    if (bodies.length == 0) return null;
+  
+    return bodies[0];
+  }
+
   function getCanvasMimeType(canvas: Canvas): string | null {
+    // presentation api version 2
     const resource: Resource | null = getCanvasImageResource(canvas);
 
     if (resource) {
       const format: MediaType | null = resource.getFormat();
+
+      if (format) {
+        return format.toString();
+      }
+    }
+
+    // presentation api version 3
+    const annotationBody: AnnotationBody | null = getCanvasImageAnnotationBody(canvas);
+    if (annotationBody) {
+      const format: MediaType | null = annotationBody.getFormat();
 
       if (format) {
         return format.toString();

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -274,7 +274,7 @@ const DownloadDialogue = ({
     const bodies: AnnotationBody[] = images[0].getBody();
     if (bodies.length == 0) {
       return null;
-    }|
+    }
   
     return bodies[0];
   }

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -267,10 +267,14 @@ const DownloadDialogue = ({
 
   function getCanvasImageAnnotationBody(canvas: Canvas): AnnotationBody | null {
     const images: Annotation[] = canvas.getContent();
-    if (images.length == 0) return null;
+    if (images.length == 0) {
+      return null;
+    }
 
     const bodies: AnnotationBody[] = images[0].getBody();
-    if (bodies.length == 0) return null;
+    if (bodies.length == 0) {
+      return null;
+    }|
   
     return bodies[0];
   }


### PR DESCRIPTION
When you use a version 3 manifest,
then the format shown next to download option `Whole image w x h (?)` shows a `?`. This is because the code tries to load the image resource the way it is done in version 2.

I added code for version 3 to derive the format

Apparently not a problem for wholeImageLowResLabel

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did: