### PR TITLE
Remove relative links from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Read the [docs](https://docs.universalviewer.io/) to learn about the various UV 
 Read below to learn how to take part in improving the UV:
 
 - Fork the repository and [run the examples from source](#-getting-started)
-- Get familiar with [Code of Conduct](CODE_OF_CONDUCT.md)
-- Read our [guide to contributing](CONTRIBUTING.md)
+- Get familiar with [Code of Conduct](https://github.com/UniversalViewer/universalviewer/blob/main/CODE_OF_CONDUCT.md)
+- Read our [guide to contributing](https://github.com/UniversalViewer/universalviewer/blob/main/CONTRIBUTING.md)
 - Find an issue to work on and submit a pull request
   - First time contributing to open source? Pick a [good first issue](https://github.com/universalviewer/universalviewer/labels/good%20first%20issue) to get you familiar with GitHub contributing process.
   - First time contributing to the UV? Pick a [beginner friendly issue](https://github.com/universalviewer/universalviewer/labels/beginners) to get you familiar with codebase and our contributing process.
@@ -84,7 +84,7 @@ Read our [Accessibility Statement](https://github.com/UniversalViewer/universalv
 
 ## 📣 Feedback
 
-Read below how to engage with the UV [community](COMMUNITY_TEAM.md):
+Read below how to engage with the UV [community](https://github.com/UniversalViewer/universalviewer/blob/main/COMMUNITY_TEAM.md):
 
 - Join the discussion on [Slack](http://universalviewer.io/#contact).
 - Ask a question, request a new feature and file a bug with [GitHub issues](https://github.com/universalviewer/universalviewer/issues/new).


### PR DESCRIPTION
As discussed in the April Community Call, we need to use absolute rather than relative URLs in the README so that links resolve correctly on the documentation site.