### PR TITLE
Bump CodeSandbox Node version to 18.

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -8,5 +8,5 @@
     "uv-nextjs-example-uh9zi"
   ],
   "buildCommand": "prepublishOnly",
-  "node": "16"
+  "node": "18"
 }


### PR DESCRIPTION
Node v16 is no longer supported; this raises the Node version used by CodeSandbox to 18, which is the lowest version still under active maintenance.