### PR TITLE
Use Node 18 in GitHub Actions.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,8 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # @TODO add 16/18
-        node: [ '16' ]
+        node: [ '18' ]
 
     name: Node ${{ matrix.node }} build
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '18.x'
       - run: npm ci
       - run: npm run build
 
@@ -38,7 +38,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '18.x'
 
       - name: Set tag
         id: tagName


### PR DESCRIPTION
Now that UV requires Node 18, we should use appropriate versions in our GitHub actions. This updates them, as per discussion on today's Community Call.