### PR TITLE
issue 923 allow search results paging on single page

### DIFF
--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -361,7 +361,6 @@ export class FooterPanel extends BaseFooterPanel<
     const currentCanvasIndex: number = this.extension.helper.canvasIndex;
     const lastSearchResultCanvasIndex: number = this.getLastSearchResultCanvasIndex();
     const currentSearchResultRectIndex: number = this.getCurrentSearchResultRectIndex();
-    const totalCanvases: number = this.extension.helper.getTotalCanvases();
 
     // if zoom to search result is enabled and there is a highlighted search result.
     if (
@@ -381,11 +380,7 @@ export class FooterPanel extends BaseFooterPanel<
       return true;
     }
 
-    // if only one canvas then allow clicking next result
-    if (totalCanvases === 1) {
-      return true}
-
-    return currentCanvasIndex < lastSearchResultCanvasIndex;
+    return currentCanvasIndex <= lastSearchResultCanvasIndex;
   }
 
   getSearchResults(): AnnotationGroup[] {

--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -361,17 +361,18 @@ export class FooterPanel extends BaseFooterPanel<
     const currentCanvasIndex: number = this.extension.helper.canvasIndex;
     const lastSearchResultCanvasIndex: number = this.getLastSearchResultCanvasIndex();
     const currentSearchResultRectIndex: number = this.getCurrentSearchResultRectIndex();
+    const totalCanvases: number = this.extension.helper.getTotalCanvases();
 
     // if zoom to search result is enabled and there is a highlighted search result.
     if (
       this.isZoomToSearchResultEnabled() &&
       (<OpenSeadragonExtension>this.extension).currentAnnotationRect
     ) {
-      if (currentCanvasIndex > lastSearchResultCanvasIndex) {
+      if (currentCanvasIndex > lastSearchResultCanvasIndex) { //if you've moved past final result page
         return false;
-      } else if (currentCanvasIndex === lastSearchResultCanvasIndex) {
+      } else if (currentCanvasIndex === lastSearchResultCanvasIndex) { // if you're on the final result page
         if (
-          currentSearchResultRectIndex === this.getLastSearchResultRectIndex()
+          currentSearchResultRectIndex === this.getLastSearchResultRectIndex() //and you're on the last result
         ) {
           return false;
         }
@@ -379,6 +380,10 @@ export class FooterPanel extends BaseFooterPanel<
 
       return true;
     }
+
+    // if only one canvas then allow clicking next result
+    if (totalCanvases === 1) {
+      return true}
 
     return currentCanvasIndex < lastSearchResultCanvasIndex;
   }


### PR DESCRIPTION
Fixes a bug identified in Issue 923 that disabled the next/previous search results buttons when the manifest had a single canvas. https://github.com/UniversalViewer/universalviewer/issues/923