### PR TITLE
Allow <em> tag in sanitized HTML.

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -8,6 +8,7 @@ export const sanitize = (html: string) => {
       a: ["href", "title", "target", "class", "data-uv-navigate"],
       b: [],
       br: [],
+      em: [],
       i: [],
       img: ["src", "alt"],
       p: [],


### PR DESCRIPTION
The UV currently allows `<i>` tags but not `<em>` tags in sanitized HTML descriptions. Since we also support both `<b>` and `<strong>` it seems to make sense to add `<em>` for completeness.