### PR TITLE
Fix broken minimiseButtons setting.

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/FooterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/FooterPanel.ts
@@ -180,16 +180,10 @@ export class FooterPanel<
 
   updateMinimisedButtons(): void {
     // if configured to always minimise buttons
-    if (Bools.getBool(this.options.minimiseButtons, false)) {
-      this.$options.addClass("minimiseButtons");
-      return;
-    }
-
-    // otherwise, check metric
-    if (!this.extension.isDesktopMetric()) {
-      this.$options.addClass("minimiseButtons");
+    if (Bools.getBool(this.options.minimiseButtons, false) || !this.extension.isDesktopMetric()) {
+      this.$options.find("span").addClass("sr-only");
     } else {
-      this.$options.removeClass("minimiseButtons");
+      this.$options.find("span").removeClass("sr-only");
     }
   }
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/footer-panel.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/footer-panel.less
@@ -23,11 +23,5 @@
               	}
             }
         }
-
-        .options.minimiseButtons {
-            .btn {
-                font-size: 0;
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR addresses #952, restoring the functionality of the minimiseButtons configuration option and removing some CSS that is no longer used.

Possibly worth discussing: would it be better to make the minimiseButtons CSS work correctly instead of relying on sr-only here? That would also be a viable solution, it would just require a different set of changes.