### PR TITLE
Move inline style to external

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -271,7 +271,7 @@ export class BaseExtension<T extends BaseConfig> implements IExtension {
 
     // this.$element.append('<a href="/" id="top"></a>');
     this.$element.append(
-      '<iframe id="commsFrame" style="display:none"></iframe>'
+      '<iframe id="commsFrame"></iframe>'
     );
 
     this.extensionHost.subscribeAll((event, args) => {

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
@@ -82,6 +82,7 @@
         width: 1px;
         height: 1px;
         border: none;
+        display: none;
     }
 
     .headerPanel {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Issue:
The Content Security Policy (CSP) prevents cross-site scripting attacks by blocking inline execution of scripts and style sheets.
To solve this, move all inline scripts (e.g. onclick=[JS code]) and styles into external files.
⚠️ Allowing inline execution comes at the risk of script injection via injection of HTML script elements. If you absolutely must, you can allow inline script and styles by:
adding unsafe-inline as a source to the CSP header
adding the hash or nonce of the inline script to your CSP header.

If possible avoiding the use of unsafe-inline is best.

- Move inline style ```display: none``` to external css class.
