### PR TITLE
Add accessible name to imageButton.searchButton (fixes #1100)

### DIFF
--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -136,6 +136,7 @@ export class FooterPanel extends BaseFooterPanel<
     this.$searchButton = $(
       '<button class="imageButton searchButton"></button>'
     );
+    this.$searchButton.attr('aria-label', this.content.searchWithin);
     this.$searchTextContainer.append(this.$searchButton);
 
     // search results.

--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -137,6 +137,7 @@ export class FooterPanel extends BaseFooterPanel<
       '<button class="imageButton searchButton"></button>'
     );
     this.$searchButton.attr('aria-label', this.content.searchWithin);
+    this.$searchButton.attr('title', this.content.searchWithin);
     this.$searchTextContainer.append(this.$searchButton);
 
     // search results.


### PR DESCRIPTION
Fixes #1100 

Sets aria-label and title on the search button with already-present searchWithin text.

en - Search within this item:
cy - Chwilio tu fewn i: