### PR TITLE
Remove fixed widths from navigation controls (fixes #1066)

### DIFF
--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/css/styles.less
@@ -54,7 +54,7 @@
             .search {
                 float: left;
                 margin: 6px 0 0 5px;
-                width: 113px;
+                width: auto;
 
                 .searchText {
                     border: none;
@@ -75,7 +75,7 @@
 
                 label {
                     clear: none;
-                    width: 30px;
+                    width: auto;
                     margin: 0 0 0 0;
                     padding: 0;
                     float: left;

--- a/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/css/styles.less
@@ -37,7 +37,7 @@
       .search {
         float: left;
         margin: 6px 0 0 5px;
-        width: 113px;
+        width: auto;
 
         .searchText {
           border: none;

--- a/src/content-handlers/iiif/themes/cy-gb/header-panel.less
+++ b/src/content-handlers/iiif/themes/cy-gb/header-panel.less
@@ -8,16 +8,6 @@
           margin: 0 10px 0 0;
         }
 
-        .mode {
-          label {
-            width: 42px;
-          }
-        }
-
-        .search {
-          width: 140px;
-        }
-
         .nextOptions {
           margin: 0 0 0 10px;
         }


### PR DESCRIPTION
Fixes #1066 

Removed fixed widths from `.mode label` and `.search` the CY less file.

Changes fixed widths to be auto in the main pdf and paging headerpanel less files.

The auto widths seem fine in all languages at both normal and increased letter spacing, and at all screen widths where the panel appears.