### PR TITLE
Fixes Accessibility issue: backwards tabbing required to access langu…

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
@@ -1,8 +1,8 @@
 const $ = require("jquery");
+import { BaseView } from "./BaseView";
+import { IIIFEvents } from "../../IIIFEvents";
 import { Maths } from "@edsilv/utils";
 import { BaseConfig } from "../../BaseConfig";
-import { IIIFEvents } from "../../IIIFEvents";
-import { BaseView } from "./BaseView";
 
 export class Dialogue<
   T extends BaseConfig["modules"]["dialogue"]
@@ -53,8 +53,8 @@ export class Dialogue<
 
     this.$closeButton = $(
       '<button type="button" class="btn btn-default close" tabindex="0">' +
-      this.content.close +
-      "</button>"
+        this.content.close +
+        "</button>"
     );
 
     this.$middle = $('<div class="middle"></div>');
@@ -124,7 +124,7 @@ export class Dialogue<
       left =
         Math.floor(
           this.extension.width() * normalisedPos -
-          this.$element.width() * normalisedPos
+            this.$element.width() * normalisedPos
         ) + horizontalPadding;
       arrowLeft = Math.floor(this.$element.width() * normalisedPos);
     }
@@ -178,7 +178,7 @@ export class Dialogue<
     this.resize();
   }
 
-  afterFirstOpen(): void { }
+  afterFirstOpen(): void {}
 
   close(): void {
     if (!this.isActive) return;

--- a/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
@@ -1,8 +1,8 @@
 const $ = require("jquery");
-import { BaseView } from "./BaseView";
-import { IIIFEvents } from "../../IIIFEvents";
 import { Maths } from "@edsilv/utils";
 import { BaseConfig } from "../../BaseConfig";
+import { IIIFEvents } from "../../IIIFEvents";
+import { BaseView } from "./BaseView";
 
 export class Dialogue<
   T extends BaseConfig["modules"]["dialogue"]
@@ -53,8 +53,8 @@ export class Dialogue<
 
     this.$closeButton = $(
       '<button type="button" class="btn btn-default close" tabindex="0">' +
-        this.content.close +
-        "</button>"
+      this.content.close +
+      "</button>"
     );
 
     this.$middle = $('<div class="middle"></div>');
@@ -124,7 +124,7 @@ export class Dialogue<
       left =
         Math.floor(
           this.extension.width() * normalisedPos -
-            this.$element.width() * normalisedPos
+          this.$element.width() * normalisedPos
         ) + horizontalPadding;
       arrowLeft = Math.floor(this.$element.width() * normalisedPos);
     }
@@ -156,11 +156,11 @@ export class Dialogue<
       if ($defaultButton.length) {
         $defaultButton.focus();
       } else {
-        // if there's no default button, focus on the first visible input
-        const $input: JQuery = this.$element.find("input:visible").first();
+        // if there's no default button, focus on the first visible input or select element
+        const $firstVisibleElement: JQuery = this.$element.find("input:visible, select:visible").first();
 
-        if ($input.length) {
-          $input.focus();
+        if ($firstVisibleElement.length) {
+          $firstVisibleElement.focus();
         } else {
           // if there's no visible first input, focus on the close button
           this.$closeButton.focus();
@@ -178,7 +178,7 @@ export class Dialogue<
     this.resize();
   }
 
-  afterFirstOpen(): void {}
+  afterFirstOpen(): void { }
 
   close(): void {
     if (!this.isActive) return;


### PR DESCRIPTION
…age settings #1071

Fixes #1071 by setting focus on the first select or input when the dialogue opens

I've not done anything to trap focus etc. as that's beyond the scope of this specific issue, and more involved than I think we have time for in the sprint.

A long-term solution would be to use a `<dialog>` element as I _think_ that covers the needed a11y requirements, but we can address that in a separate issue / future sprint.