### PR TITLE
Replaced divs with label class with label element (fixes #1103)

### DIFF
--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -177,7 +177,7 @@ export class FooterPanel extends BaseFooterPanel<
     this.$pagePositionMarker = $('<div class="positionPlacemarker"></div>');
     this.$searchResultsContainer.append(this.$pagePositionMarker);
 
-    this.$pagePositionLabel = $('<div class="label"></div>');
+    this.$pagePositionLabel = $('<label class="label"></label>');
     this.$searchResultsContainer.append(this.$pagePositionLabel);
 
     this.$placemarkerDetails = $('<div class="placeMarkerDetails"></div>');


### PR DESCRIPTION
Fixes #1103 

Only remaining instance was the page position label in the footer:
![image](https://github.com/user-attachments/assets/df82b579-0215-4d73-a170-eaafa17ce090)
