### PR TITLE
Fix keyboard thumbnail activation (fixes #1068)

### DIFF
--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -13,6 +13,8 @@ import OpenSeadragonExtension from "../../extensions/uv-openseadragon-extension/
 import { LeftPanel } from "../uv-shared-module/LeftPanel";
 import { Mode } from "../../extensions/uv-openseadragon-extension/Mode";
 import { TreeView } from "./TreeView";
+//import * as KeyCodes from "@edsilv/key-codes";
+
 import {
   LanguageMap,
   Thumb,
@@ -23,6 +25,8 @@ import {
 import { AnnotationGroup, TreeSortType } from "@iiif/manifold";
 import { isVisible } from "../../../../Utils";
 import { ContentLeftPanel as ContentLeftPanelConfig } from "../../extensions/config/ContentLeftPanel";
+//import keycodes, { KeyDownEnter } from "@edsilv/key-codes";
+//import { KeyDown } from "@edsilv/key-codes";
 
 export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
   $bottomOptions: JQuery;
@@ -44,10 +48,12 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
   $treeViewOptions: JQuery;
   $treeSelect: JQuery;
   $views: JQuery;
+  $keyElement: JQuery
   expandFullEnabled: boolean = false;
   galleryView: GalleryView;
   isThumbsViewOpen: boolean = false;
   isTreeViewOpen: boolean = false;
+  keyPress:boolean = false;
   treeData: TreeNode;
   treeSortType: TreeSortType = TreeSortType.NONE;
   treeView: TreeView;
@@ -505,12 +511,23 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
         onClick: (thumb: Thumb) => {
           this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
         },
-        onKeyDown: (thumb: Thumb) => {
-          this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
+        onKeyDown: (thumb: Thumb) => { 
+          //this.handleKeyPress(); 
+          //this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);        
+          
+            this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
+                                             
         },
+
+
+        
       })
     );
   }
+
+  /* this.$keyElement.on("keydown", (e: any) => {
+    this.keyPress = e.keyCode === KeyDown.Enter;
+  }); */
 
   createGalleryView(): void {
     this.galleryView = new GalleryView(this.$galleryView);

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -13,8 +13,6 @@ import OpenSeadragonExtension from "../../extensions/uv-openseadragon-extension/
 import { LeftPanel } from "../uv-shared-module/LeftPanel";
 import { Mode } from "../../extensions/uv-openseadragon-extension/Mode";
 import { TreeView } from "./TreeView";
-//import * as KeyCodes from "@edsilv/key-codes";
-
 import {
   LanguageMap,
   Thumb,
@@ -25,8 +23,6 @@ import {
 import { AnnotationGroup, TreeSortType } from "@iiif/manifold";
 import { isVisible } from "../../../../Utils";
 import { ContentLeftPanel as ContentLeftPanelConfig } from "../../extensions/config/ContentLeftPanel";
-//import keycodes, { KeyDownEnter } from "@edsilv/key-codes";
-//import { KeyDown } from "@edsilv/key-codes";
 
 export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
   $bottomOptions: JQuery;
@@ -511,24 +507,12 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
         onClick: (thumb: Thumb) => {
           this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
         },
-        onKeyDown: (thumb: Thumb) => { 
-          //this.handleKeyPress(); 
-          //this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);        
-          
-            this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
-                                             
-        },
-
-
-        
+        onKeyDown: (thumb: Thumb) => {          
+            this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);                                             
+        },        
       })
     );
   }
-
-  /* this.$keyElement.on("keydown", (e: any) => {
-    this.keyPress = e.keyCode === KeyDown.Enter;
-  }); */
-
   createGalleryView(): void {
     this.galleryView = new GalleryView(this.$galleryView);
     this.galleryView.galleryData = this.getGalleryData();

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -505,6 +505,9 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
         onClick: (thumb: Thumb) => {
           this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
         },
+        onKeyDown: (thumb: Thumb) => {
+          this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
+        },
       })
     );
   }

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -3,11 +3,6 @@ import { Thumb } from "manifesto.js";
 import { ViewingDirection, ViewingHint } from "@iiif/vocabulary";
 import { useInView } from "react-intersection-observer";
 import cx from "classnames";
-//import  KeyDownEnter  from "@edsilv/key-codes";
-//import { event } from "jquery";
-//import  KeyDown  from "@edsilv/key-codes";
-//import * as KeyCodes from "@edsilv/key-codes";
-//import { IIIFEvents } from "../../IIIFEvents";
 
 const ThumbImage = ({
   first,

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -7,6 +7,7 @@ import cx from "classnames";
 const ThumbImage = ({
   first,
   onClick,
+  onKeyDown,
   paged,
   selected,
   thumb,
@@ -14,6 +15,7 @@ const ThumbImage = ({
 }: {
   first: boolean;
   onClick: (thumb: Thumb) => void;
+  onKeyDown: (thumb: Thumb) => void;
   paged: boolean;
   selected: boolean;
   thumb: Thumb;
@@ -28,6 +30,7 @@ const ThumbImage = ({
   return (
     <div
       onClick={() => onClick(thumb)}
+      onKeyDown={() => onKeyDown(thumb)}
       className={cx("thumb", {
         first: first,
         placeholder: !thumb.uri,
@@ -64,12 +67,14 @@ const ThumbImage = ({
 
 const Thumbnails = ({
   onClick,
+  onKeyDown,
   paged,
   selected,
   thumbs,
   viewingDirection,
 }: {
   onClick: (thumb: Thumb) => void;
+  onKeyDown: (thumb: Thumb) => void;
   paged: boolean;
   selected: number[];
   thumbs: Thumb[];
@@ -122,6 +127,7 @@ const Thumbnails = ({
           <ThumbImage
             first={index === firstNonPagedIndex}
             onClick={onClick}
+            onKeyDown={onKeyDown}
             paged={paged}
             selected={selected.includes(index)}
             thumb={thumb}

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -3,6 +3,11 @@ import { Thumb } from "manifesto.js";
 import { ViewingDirection, ViewingHint } from "@iiif/vocabulary";
 import { useInView } from "react-intersection-observer";
 import cx from "classnames";
+//import  KeyDownEnter  from "@edsilv/key-codes";
+//import { event } from "jquery";
+//import  KeyDown  from "@edsilv/key-codes";
+//import * as KeyCodes from "@edsilv/key-codes";
+//import { IIIFEvents } from "../../IIIFEvents";
 
 const ThumbImage = ({
   first,
@@ -30,7 +35,7 @@ const ThumbImage = ({
   return (
     <div
       onClick={() => onClick(thumb)}
-      onKeyDown={() => onKeyDown(thumb)}
+      onKeyDown= {(e) => {if(e.key === 'Enter'){onKeyDown(thumb)}}}
       className={cx("thumb", {
         first: first,
         placeholder: !thumb.uri,


### PR DESCRIPTION
This PR addresses #1068.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:
Inside the contents left sidebar users can activate images from the thumbnails. They can tab through and then activate the image to make it display in the image viewer. 