### PR TITLE
Makes disable animations work across all extensions' expand panels and makes it a global config

### DIFF
--- a/src/content-handlers/iiif/BaseConfig.ts
+++ b/src/content-handlers/iiif/BaseConfig.ts
@@ -102,6 +102,9 @@ export type Options = {
 
   /** Determines if zoom to bounds is enabled */
   zoomToBoundsEnabled?: boolean;
+
+  /** Controls whether to have animations or not */
+  reducedAnimation?: boolean;
 };
 
 type Locale = {

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
@@ -1371,12 +1371,14 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
     const config: string = this.data.config!.uri || "";
     const locales: string | null = this.getSerializedLocales();
     const appUri: string = this.getAppUri();
+    const title: string = this.helper.getLabel() || "";
     const iframeSrc: string = `${appUri}#?manifest=${this.helper.manifestUri}&c=${this.helper.collectionIndex}&m=${this.helper.manifestIndex}&cv=${this.helper.canvasIndex}&config=${config}&locales=${locales}&xywh=${zoom}&r=${rotation}`;
     const script: string = Strings.format(
       template,
       iframeSrc,
       width.toString(),
-      height.toString()
+      height.toString(),
+      title
     );
     return script;
   }

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
@@ -483,8 +483,6 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
         IIIFEvents.CANVAS_INDEX_CHANGE,
         this.helper.canvasIndex
       );
-      const settings: ISettings = this.getSettings();
-      this.extensionHost.publish(IIIFEvents.SETTINGS_CHANGE, settings);
     });
 
     this.extensionHost.subscribe(
@@ -1373,14 +1371,12 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
     const config: string = this.data.config!.uri || "";
     const locales: string | null = this.getSerializedLocales();
     const appUri: string = this.getAppUri();
-    const title: string = this.helper.getLabel() || "";
     const iframeSrc: string = `${appUri}#?manifest=${this.helper.manifestUri}&c=${this.helper.collectionIndex}&m=${this.helper.manifestIndex}&cv=${this.helper.canvasIndex}&config=${config}&locales=${locales}&xywh=${zoom}&r=${rotation}`;
     const script: string = Strings.format(
       template,
       iframeSrc,
       width.toString(),
-      height.toString(),
-      title
+      height.toString()
     );
     return script;
   }

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/SettingsDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/SettingsDialogue.ts
@@ -138,6 +138,14 @@ export class SettingsDialogue extends Dialogue<
 
     this.$reducedAnimation.append(this.$reducedAnimationLabel);
 
+    const settings: ISettings = this.getSettings();
+
+    if (settings.reducedAnimation) {
+      this.$reducedAnimationCheckbox.prop("checked", true);
+    } else {
+      this.$reducedAnimationCheckbox.removeAttr("checked");
+    }
+
     this.$reducedAnimationCheckbox.change(() => {
       const settings: ISettings = {};
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -10,7 +10,6 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
   isUnopened: boolean = true;
   autoToggled: boolean = false;
   expandFullEnabled: boolean = true;
-  reducedAnimation = false;
 
   $closed: JQuery;
   $closedTitle: JQuery;
@@ -98,7 +97,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     this.extensionHost.subscribe(
       IIIFEvents.SETTINGS_CHANGE,
       (args: ISettings) => {
-        this.reducedAnimation = args.reducedAnimation || false;
+        //this.reducedAnimation = args.reducedAnimation || false;
       }
     );
   }
@@ -113,6 +112,10 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
   }
 
   toggle(autoToggled?: boolean): void {
+
+    const settings = this.extension.getSettings();
+    let isReducedAnimation = settings.reducedAnimation;
+
     autoToggled ? (this.autoToggled = true) : (this.autoToggled = false);
 
     // if collapsing, hide contents immediately.
@@ -125,7 +128,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
       this.$closed.show();
     }
 
-    if (this.reducedAnimation) {
+    if (isReducedAnimation) {
       // This is reduced motion.
       this.$element.css("width", this.getTargetWidth());
       this.$element.css("left", this.getTargetLeft());

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -92,14 +92,6 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
 
     this.$top.hide();
     this.$main.hide();
-
-    // Subscribe to settings change.
-    this.extensionHost.subscribe(
-      IIIFEvents.SETTINGS_CHANGE,
-      (args: ISettings) => {
-        //this.reducedAnimation = args.reducedAnimation || false;
-      }
-    );
   }
 
   init(): void {

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -1,7 +1,6 @@
 const $ = require("jquery");
 import { BaseView } from "./BaseView";
 import { Bools } from "@edsilv/utils";
-import { IIIFEvents } from "../../IIIFEvents";
 import { ExpandPanel } from "../../extensions/config/ExpandPanel";
 
 export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -474,11 +474,6 @@ export class BaseExtension<T extends BaseConfig> implements IExtension {
       this.extensionHost.publish(Events.CREATED);
       this._setDefaultFocus();
     }, 1);
-
-    this.extensionHost.subscribe(IIIFEvents.UPDATE_SETTINGS, () => {
-      const settings: ISettings = this.getSettings();
-      this.extensionHost.publish(IIIFEvents.SETTINGS_CHANGE, settings);
-    });
   }
 
   public async loadConfig(locale: string, extension: string): Promise<any> {

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -475,7 +475,6 @@ export class BaseExtension<T extends BaseConfig> implements IExtension {
       this._setDefaultFocus();
     }, 1);
 
-    
     this.extensionHost.subscribe(IIIFEvents.UPDATE_SETTINGS, () => {
       const settings: ISettings = this.getSettings();
       this.extensionHost.publish(IIIFEvents.SETTINGS_CHANGE, settings);

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -474,6 +474,12 @@ export class BaseExtension<T extends BaseConfig> implements IExtension {
       this.extensionHost.publish(Events.CREATED);
       this._setDefaultFocus();
     }, 1);
+
+    
+    this.extensionHost.subscribe(IIIFEvents.UPDATE_SETTINGS, () => {
+      const settings: ISettings = this.getSettings();
+      this.extensionHost.publish(IIIFEvents.SETTINGS_CHANGE, settings);
+    });
   }
 
   public async loadConfig(locale: string, extension: string): Promise<any> {


### PR DESCRIPTION
Fixes #756 

Reduced animations should now be available as a global config setting on the in-use extension so if any other modules have animations in future they can refer to it.

Also fixes the problem where the config didn't persist between refreshes.

Tested locally on OSD, PDF, Video, Audio, & 3D

