### PR TITLE
Add attribution close label (fixes #1075)

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-aleph-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-aleph-extension/config/config.json
@@ -213,7 +213,7 @@
       },
       "content": {
         "attribution": "$attribution",
-        "close": "$close"
+        "close": "$closeAttribution"
       }
     },
     "settingsDialogue": {

--- a/src/content-handlers/iiif/extensions/uv-av-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-av-extension/config/config.json
@@ -249,7 +249,7 @@
       },
       "content": {
         "attribution": "$attribution",
-        "close": "$close",
+        "close": "$closeAttribution",
         "currentTime": "$currentTime",
         "delimiter": " - ",
         "duration": "$duration",

--- a/src/content-handlers/iiif/extensions/uv-default-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-default-extension/config/config.json
@@ -106,7 +106,7 @@
       },
       "content": {
         "attribution": "$attribution",
-        "close": "$close"
+        "close": "$closeAttribution"
       }
     },
     "footerPanel": {

--- a/src/content-handlers/iiif/extensions/uv-ebook-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-ebook-extension/config/config.json
@@ -208,7 +208,7 @@
       },
       "content": {
         "attribution": "$attribution",
-        "close": "$close"
+        "close": "$closeAttribution"
       }
     },
     "settingsDialogue": {

--- a/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/config.json
@@ -169,7 +169,7 @@
       },
       "content": {
         "attribution": "$attribution",
-        "close": "$close"
+        "close": "$closeAttribution"
       }
     },
     "restrictedDialogue": {

--- a/src/content-handlers/iiif/extensions/uv-model-viewer-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-model-viewer-extension/config/config.json
@@ -261,7 +261,7 @@
       },
       "content": {
         "attribution": "$attribution",
-        "close": "$close",
+        "close": "$closeAttribution",
         "zoomIn": "$zoomIn",
         "zoomOut": "$zoomOut",
         "vr": "$vr"

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
@@ -363,7 +363,7 @@
       },
       "content": {
         "attribution": "$attribution",
-        "close": "$close",
+        "close": "$closeAttribution",
         "goHome": "$goHome",
         "imageUnavailable": "$imageUnavailable",
         "next": "$next",

--- a/src/content-handlers/iiif/extensions/uv-pdf-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-pdf-extension/config/config.json
@@ -199,7 +199,7 @@
       },
       "content": {
         "attribution": "$attribution",
-        "close": "$close",
+        "close": "$closeAttribution",
         "next": "$next",     
         "previous": "$previous"
       }

--- a/src/locales/cy-GB.json
+++ b/src/locales/cy-GB.json
@@ -13,6 +13,7 @@
   "$contents": "Cynnwys",
   "$volume": "cyfrol",
   "$close": "Cau",
+  "$closeAttribution": "Cau panel priodoledd",
   "$allPages": "Pob Tudalen",
   "$currentViewAsJpg": "Delwedd ddethol {0} x {1}px (jpg)",
   "$openNewWindow": "Agor mewn dwy ffenest newydd.",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -13,6 +13,7 @@
   "$contents": "Contents",
   "$volume": "volume",
   "$close": "Close",
+  "$closeAttribution": "Close attribution panel",
   "$allPages": "All Pages",
   "$currentViewAsJpg": "Current view {0} x {1}px (jpg)",
   "$openNewWindow": "Opens in a new window",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -13,6 +13,7 @@
   "$contents": "Contenus",
   "$volume": "volume",
   "$close": "Fermer",
+  "$closeAttribution": "Close attribution panel",
   "$allPages": "Toutes les pages",
   "$currentViewAsJpg": "Vue actuelle {0} x {1}px (jpg)",
   "$openNewWindow": "Ouvre une nouvelle fenêtre",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -13,7 +13,7 @@
   "$contents": "Contenus",
   "$volume": "volume",
   "$close": "Fermer",
-  "$closeAttribution": "Close attribution panel",
+  "$closeAttribution": "Fermer le panneau d'attribution",
   "$allPages": "Toutes les pages",
   "$currentViewAsJpg": "Vue actuelle {0} x {1}px (jpg)",
   "$openNewWindow": "Ouvre une nouvelle fenêtre",

--- a/src/locales/pl-PL.json
+++ b/src/locales/pl-PL.json
@@ -13,7 +13,7 @@
   "$contents": "Zawartość",
   "$volume": "tom",
   "$close": "Zamknij",
-  "$closeAttribution": "Close attribution panel",
+  "$closeAttribution": "Zamknij panel atrybucji",
   "$allPages": "Wszystkie strony",
   "$currentViewAsJpg": "Aktualny widok {0} x {1}px (jpg)",
   "$openNewWindow": "Otwiera się w nowym oknie",

--- a/src/locales/pl-PL.json
+++ b/src/locales/pl-PL.json
@@ -13,6 +13,7 @@
   "$contents": "Zawartość",
   "$volume": "tom",
   "$close": "Zamknij",
+  "$closeAttribution": "Close attribution panel",
   "$allPages": "Wszystkie strony",
   "$currentViewAsJpg": "Aktualny widok {0} x {1}px (jpg)",
   "$openNewWindow": "Otwiera się w nowym oknie",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -13,6 +13,7 @@
   "$contents": "Innehåll",
   "$volume": "volym",
   "$close": "Stäng",
+  "$closeAttribution": "Stäng upphovspanelen",
   "$allPages": "Alla sidor",
   "$currentViewAsJpg": "Aktuell vy {0} x {1}px (jpg)",
   "$openNewWindow": "Öppnas i nytt fönster",


### PR DESCRIPTION
Fixes #1075 

Added `$closeAttribution` string and added to all extensions.
Translations added: en-GB, cy-GB, sv-SE
Additional translations required: fr-FR, pl-PL

Tested using VoiceOver on MacOS with the following manifests:
https://eap.bl.uk/archive-file/EAP500-1-1/manifest
https://damsssl.llgc.org.uk/iiif/2.0/2373813/manifest.json
http://dams.llgc.org.uk/iiif/2.0/4389767/manifest.json
http://dams.llgc.org.uk/iiif/2.0/1123257/manifest.json
http://dams.llgc.org.uk/iiif/archive/3975658/fonds.json
http://iiif.bodleian.ox.ac.uk/iiif/manifest/60834383-7146-41ab-bfe1-48ee97bc04be.json
https://digital.library.villanova.edu/Item/vudl:24299/Manifest
https://digital.library.villanova.edu/Collection/vudl:3/IIIF
https://digital.library.villanova.edu/Item/vudl:60609/Manifest
https://digital.library.villanova.edu/Item/vudl:30471/Manifest
https://edsilv.github.io/test-manifests/non-paged.json
https://edsilv.github.io/test-manifests/download-service-enabled.json
https://edsilv.github.io/test-manifests/download-service-disabled.json
https://d.lib.ncsu.edu/collections/catalog/nubian-message-2003-04-01/manifest?v3=true
https://purl.stanford.edu/bh502xm3351/iiif3/manifest
https://biiif-template-example-3kntb3jpl-mnemoscene.vercel.app/audio/index.json
https://biiif-template-example-3kntb3jpl-mnemoscene.vercel.app/pdf/index.json
https://biiif-template-zine.vercel.app/index.json
