### PR TITLE
Restrict tab focus to within modal dialogues when open (fixes #1070 and #1072)

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -78,10 +78,6 @@ const DownloadDialogue = ({
   triggerButton: HTMLElement;
 }) => {
   const ref = useRef<HTMLDivElement>(null);
-
-  const firstFocusableElementRef = useRef<HTMLButtonElement | null>(null);
-  const lastFocusableElementRef = useRef<HTMLButtonElement | null>(null);
-
   const [position, setPosition] = useState({ top: "0px", left: "0px" });
   const [arrowPosition, setArrowPosition] = useState("0px 0px");
   const [selectedPage, setSelectedPage] = useState<"left" | "right">("left");
@@ -114,16 +110,25 @@ const DownloadDialogue = ({
       setArrowPosition(`${arrowLeft}px 0px`);
 
       // Focus on the first element when opened
-      firstFocusableElementRef.current?.focus();
+      const focusableElements = getFocusableElements();
+      if (focusableElements && focusableElements.length > 0) {
+        focusableElements[0]?.focus();
+      }
     }
   }, [open]);
+
+  // Method to get focusable elements inside the component
+  const getFocusableElements = (): NodeListOf<HTMLElement> | null => {
+    return ref.current?.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    ) as NodeListOf<HTMLElement>;
+  };
+
 
   // Focus trapping logic
   const handleTabKey = (e: KeyboardEvent) => {
     if (e.key === "Tab") {
-      const focusableElements = ref.current?.querySelectorAll(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
+      const focusableElements = getFocusableElements();
       if (!focusableElements) return;
 
       const firstFocusableElement = focusableElements[0] as HTMLElement;
@@ -602,7 +607,7 @@ const DownloadDialogue = ({
           <ol className="options">
             {isDownloadOptionAvailable(DownloadOption.CURRENT_VIEW) && (
               <li className="option single">
-                <button ref={firstFocusableElementRef}
+                <button
                   onClick={() => {
                     onDownloadCurrentView(getSelectedCanvas());
                   }}
@@ -613,7 +618,7 @@ const DownloadDialogue = ({
             )}
             {isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_HIGH_RES) && (
               <li className="option single">
-                <button ref={lastFocusableElementRef}
+                <button
                   onClick={() => {
                     window.open(getCanvasHighResImageUri(getSelectedCanvas()));
                   }}

--- a/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
@@ -28,7 +28,7 @@ export class Dialogue<
 
   create(): void {
     this.setConfig("dialogue");
-
+    
     super.create();
 
     // events.
@@ -168,6 +168,9 @@ export class Dialogue<
       }
     }, 1);
 
+    // Add keydown event listener to trap focus within the dialog
+    this.$element.on("keydown", (e: JQuery.Event) => this.handleKeydown(e));
+
     this.extensionHost.publish(IIIFEvents.SHOW_OVERLAY);
 
     if (this.isUnopened) {
@@ -186,6 +189,9 @@ export class Dialogue<
     this.$element.hide();
     this.isActive = false;
 
+    // Remove the keydown event listener
+    this.$element.off("keydown");
+
     this.extensionHost.publish(this.closeCommand);
     this.extensionHost.publish(IIIFEvents.HIDE_OVERLAY);
   }
@@ -197,5 +203,31 @@ export class Dialogue<
       top: Math.floor(this.extension.height() / 2 - this.$element.height() / 2),
       left: Math.floor(this.extension.width() / 2 - this.$element.width() / 2),
     });
+  }
+
+  private handleKeydown(event: JQuery.Event): void {
+    if (event.key === "Tab") {
+        const focusableSelectors =
+            'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], select, [tabindex="0"]';
+        const focusableElements = this.$element.find(focusableSelectors).filter(':visible');
+
+        const firstElement = focusableElements.first()[0];
+        const lastElement = focusableElements.last()[0];
+        const activeElement = document.activeElement;
+
+        if (event.shiftKey) {
+            // Shift + Tab (backwards)
+            if (activeElement === firstElement) {
+                event.preventDefault();
+                lastElement.focus();
+            }
+        } else {
+            // Tab (forwards)
+            if (activeElement === lastElement) {
+                event.preventDefault();
+                firstElement.focus();
+            }
+        }
+    }
   }
 }

--- a/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
@@ -28,7 +28,6 @@ export class Dialogue<
 
   create(): void {
     this.setConfig("dialogue");
-    
     super.create();
 
     // events.


### PR DESCRIPTION
Restrict tab focus to within modal dialogues when open. fix issues #1070 and #1072 

 - So the Dialogue.ts which is the Base for the majority of Dialogues now traps the focus when it is opened using a key listener on the TAB and TAB + SHIFT keys
 - The Dialogue anomaly is the DownloadDialogue.tsx within the uv-openseadragon extension which is a React component. I have implemented the same here and made some changes following a previous pull request so that we now dynamically get the first focusable element. 