### PR TITLE
Make keyboard activation consistent

### DIFF
--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -6,23 +6,23 @@ const ViewingDirectionEnum = require("@iiif/vocabulary/dist-commonjs/")
   .ViewingDirection;
 // const ViewingHintEnum = require("@iiif/vocabulary/dist-commonjs/").ViewingHint;
 import { Bools } from "@edsilv/utils";
-import { AnnotationGroup, TreeSortType } from "@iiif/manifold";
-import { ViewingDirection, ViewingHint } from "@iiif/vocabulary/dist-commonjs/";
+import { ViewingHint, ViewingDirection } from "@iiif/vocabulary/dist-commonjs/";
+import { IIIFEvents } from "../../IIIFEvents";
+import { GalleryView } from "./GalleryView";
+import OpenSeadragonExtension from "../../extensions/uv-openseadragon-extension/Extension";
+import { LeftPanel } from "../uv-shared-module/LeftPanel";
+import { Mode } from "../../extensions/uv-openseadragon-extension/Mode";
+import { TreeView } from "./TreeView";
 import {
   LanguageMap,
-  Range,
   Thumb,
   TreeNode,
   TreeNodeType,
+  Range,
 } from "manifesto.js";
+import { AnnotationGroup, TreeSortType } from "@iiif/manifold";
 import { isVisible } from "../../../../Utils";
 import { ContentLeftPanel as ContentLeftPanelConfig } from "../../extensions/config/ContentLeftPanel";
-import OpenSeadragonExtension from "../../extensions/uv-openseadragon-extension/Extension";
-import { Mode } from "../../extensions/uv-openseadragon-extension/Mode";
-import { IIIFEvents } from "../../IIIFEvents";
-import { LeftPanel } from "../uv-shared-module/LeftPanel";
-import { GalleryView } from "./GalleryView";
-import { TreeView } from "./TreeView";
 
 export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
   $bottomOptions: JQuery;

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -211,11 +211,11 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
 
     this.onAccessibleClick(this.$treeButton, () => {
       this.openTreeView();
-    });
+    }, true, true);
 
     this.onAccessibleClick(this.$thumbsButton, () => {
       this.openThumbsView();
-    });
+    }, true, true);
 
     this.setTitle(this.content.title);
 

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -6,23 +6,23 @@ const ViewingDirectionEnum = require("@iiif/vocabulary/dist-commonjs/")
   .ViewingDirection;
 // const ViewingHintEnum = require("@iiif/vocabulary/dist-commonjs/").ViewingHint;
 import { Bools } from "@edsilv/utils";
-import { ViewingHint, ViewingDirection } from "@iiif/vocabulary/dist-commonjs/";
-import { IIIFEvents } from "../../IIIFEvents";
-import { GalleryView } from "./GalleryView";
-import OpenSeadragonExtension from "../../extensions/uv-openseadragon-extension/Extension";
-import { LeftPanel } from "../uv-shared-module/LeftPanel";
-import { Mode } from "../../extensions/uv-openseadragon-extension/Mode";
-import { TreeView } from "./TreeView";
+import { AnnotationGroup, TreeSortType } from "@iiif/manifold";
+import { ViewingDirection, ViewingHint } from "@iiif/vocabulary/dist-commonjs/";
 import {
   LanguageMap,
+  Range,
   Thumb,
   TreeNode,
   TreeNodeType,
-  Range,
 } from "manifesto.js";
-import { AnnotationGroup, TreeSortType } from "@iiif/manifold";
 import { isVisible } from "../../../../Utils";
 import { ContentLeftPanel as ContentLeftPanelConfig } from "../../extensions/config/ContentLeftPanel";
+import OpenSeadragonExtension from "../../extensions/uv-openseadragon-extension/Extension";
+import { Mode } from "../../extensions/uv-openseadragon-extension/Mode";
+import { IIIFEvents } from "../../IIIFEvents";
+import { LeftPanel } from "../uv-shared-module/LeftPanel";
+import { GalleryView } from "./GalleryView";
+import { TreeView } from "./TreeView";
 
 export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
   $bottomOptions: JQuery;
@@ -504,6 +504,12 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
         selected: selectedIndices,
         onClick: (thumb: Thumb) => {
           this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
+        },
+        onKeyDown: (event: React.KeyboardEvent, thumb: Thumb) => {
+          if(event.key === 'Enter' || event.code === 'Space') {
+            event.preventDefault();
+            this.extensionHost.publish(IIIFEvents.THUMB_SELECTED, thumb);
+          }
         },
       })
     );

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -27,10 +27,6 @@ const ThumbImage = ({
     triggerOnce: true,
   });
 
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    onKeyDown(event, thumb); // Pass both the event and the thumb to the onKeyDown handler
-  };
-
   return (
     <div
       onClick={() => onClick(thumb)}

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useRef } from "react";
-import { Thumb } from "manifesto.js";
 import { ViewingDirection, ViewingHint } from "@iiif/vocabulary";
-import { useInView } from "react-intersection-observer";
 import cx from "classnames";
+import { Thumb } from "manifesto.js";
+import React, { useEffect, useRef } from "react";
+import { useInView } from "react-intersection-observer";
 
 const ThumbImage = ({
   first,
   onClick,
+  onKeyDown,
   paged,
   selected,
   thumb,
@@ -14,6 +15,7 @@ const ThumbImage = ({
 }: {
   first: boolean;
   onClick: (thumb: Thumb) => void;
+  onKeyDown: (event: React.KeyboardEvent, thumb: Thumb) => void;
   paged: boolean;
   selected: boolean;
   thumb: Thumb;
@@ -25,9 +27,14 @@ const ThumbImage = ({
     triggerOnce: true,
   });
 
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    onKeyDown(event, thumb); // Pass both the event and the thumb to the onKeyDown handler
+  };
+
   return (
     <div
       onClick={() => onClick(thumb)}
+      onKeyDown={handleKeyDown}
       className={cx("thumb", {
         first: first,
         placeholder: !thumb.uri,
@@ -64,12 +71,14 @@ const ThumbImage = ({
 
 const Thumbnails = ({
   onClick,
+  onKeyDown,
   paged,
   selected,
   thumbs,
   viewingDirection,
 }: {
   onClick: (thumb: Thumb) => void;
+  onKeyDown: (event: React.KeyboardEvent, thumb: Thumb) => void;
   paged: boolean;
   selected: number[];
   thumbs: Thumb[];
@@ -122,6 +131,7 @@ const Thumbnails = ({
           <ThumbImage
             first={index === firstNonPagedIndex}
             onClick={onClick}
+            onKeyDown={onKeyDown}
             paged={paged}
             selected={selected.includes(index)}
             thumb={thumb}

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -1,8 +1,8 @@
-import { ViewingDirection, ViewingHint } from "@iiif/vocabulary";
-import cx from "classnames";
-import { Thumb } from "manifesto.js";
 import React, { useEffect, useRef } from "react";
+import { Thumb } from "manifesto.js";
+import { ViewingDirection, ViewingHint } from "@iiif/vocabulary";
 import { useInView } from "react-intersection-observer";
+import cx from "classnames";
 
 const ThumbImage = ({
   first,

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/AdjustImageDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/AdjustImageDialogue.ts
@@ -147,6 +147,9 @@ export class AdjustImageDialogue extends Dialogue<
         }
         this.shell.$overlays.css('background', '');
         super.close();
+
+        // put focus back on the button when the dialogue is closed
+        (<OpenSeadragonExtension>(this.extension)).centerPanel.$adjustImageButton.focus();
     }
 
     resize(): void {

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/ShareDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/ShareDialogue.ts
@@ -219,11 +219,11 @@ export class ShareDialogue<
 
     this.onAccessibleClick(this.$shareButton, () => {
       this.openShareView();
-    });
+    }, true, true);
 
     this.onAccessibleClick(this.$embedButton, () => {
       this.openEmbedView();
-    });
+    }, true, true);
 
     this.$customSizeDropDown.change(() => {
       this.update();

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -368,7 +368,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.onAccessibleClick(this.$zoomInButton, () => {
       this.zoomIn();
-    }, false, true);
+    });
 
     this.$zoomOutButton = this.$viewer.find('div[title="Zoom out"]');
     this.$zoomOutButton.attr("tabindex", 0);
@@ -378,7 +378,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.onAccessibleClick(this.$zoomOutButton, () => {
       this.zoomOut();
-    }, false, true);
+    });
 
     this.$goHomeButton = this.$viewer.find('div[title="Go home"]');
     this.$goHomeButton.attr("tabindex", 0);
@@ -388,7 +388,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.onAccessibleClick(this.$goHomeButton, () => {
       this.goHome();
-    }, false, true);
+    });
 
     this.$rotateButton = this.$viewer.find('div[title="Rotate right"]');
     this.$rotateButton.attr("tabindex", 0);
@@ -398,7 +398,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.onAccessibleClick(this.$rotateButton, () => {
       this.rotateRight();
-    }, false, true);
+    });
 
     if (this.showAdjustImageButton) {
       this.$adjustImageButton = this.$rotateButton.clone();
@@ -411,7 +411,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
       this.onAccessibleClick(this.$adjustImageButton, () => {
         this.extensionHost.publish(IIIFEvents.SHOW_ADJUSTIMAGE_DIALOGUE);
-      }, false, true);
+      });
     }
 
     this.$viewportNavButtonsContainer = this.$viewer.find(

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -366,6 +366,10 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     this.$zoomInButton.prop("aria-label", this.content.zoomIn);
     this.$zoomInButton.addClass("zoomIn viewportNavButton");
 
+    this.onAccessibleClick(this.$zoomInButton, () => {
+      console.log(this.viewer);
+    }, false, true);
+
     this.$zoomOutButton = this.$viewer.find('div[title="Zoom out"]');
     this.$zoomOutButton.attr("tabindex", 0);
     this.$zoomOutButton.prop("title", this.content.zoomOut);

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -367,7 +367,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     this.$zoomInButton.addClass("zoomIn viewportNavButton");
 
     this.onAccessibleClick(this.$zoomInButton, () => {
-      console.log(this.viewer);
+      this.zoomIn();
     }, false, true);
 
     this.$zoomOutButton = this.$viewer.find('div[title="Zoom out"]');
@@ -376,17 +376,29 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     this.$zoomOutButton.prop("aria-label", this.content.zoomOut);
     this.$zoomOutButton.addClass("zoomOut viewportNavButton");
 
+    this.onAccessibleClick(this.$zoomOutButton, () => {
+      this.zoomOut();
+    }, false, true);
+
     this.$goHomeButton = this.$viewer.find('div[title="Go home"]');
     this.$goHomeButton.attr("tabindex", 0);
     this.$goHomeButton.prop("title", this.content.goHome);
     this.$goHomeButton.prop("aria-label", this.content.goHome);
     this.$goHomeButton.addClass("goHome viewportNavButton");
 
+    this.onAccessibleClick(this.$goHomeButton, () => {
+      this.goHome();
+    }, false, true);
+
     this.$rotateButton = this.$viewer.find('div[title="Rotate right"]');
     this.$rotateButton.attr("tabindex", 0);
     this.$rotateButton.prop("title", this.content.rotateRight);
     this.$rotateButton.prop("aria-label", this.content.rotateRight);
     this.$rotateButton.addClass("rotate viewportNavButton");
+
+    this.onAccessibleClick(this.$rotateButton, () => {
+      this.rotateRight();
+    }, false, true);
 
     if (this.showAdjustImageButton) {
       this.$adjustImageButton = this.$rotateButton.clone();
@@ -396,6 +408,10 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
         this.extensionHost.publish(IIIFEvents.SHOW_ADJUSTIMAGE_DIALOGUE);
       });
       this.$adjustImageButton.insertAfter(this.$rotateButton);
+
+      this.onAccessibleClick(this.$adjustImageButton, () => {
+        this.extensionHost.publish(IIIFEvents.SHOW_ADJUSTIMAGE_DIALOGUE);
+      }, false, true);
     }
 
     this.$viewportNavButtonsContainer = this.$viewer.find(

--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -407,13 +407,13 @@ export class PagingHeaderPanel extends HeaderPanel<
       $(this).select();
     });
 
-    this.$searchButton.onPressed(() => {
+    this.onAccessibleClick(this.$searchButton, () => {
       if (this.options.autoCompleteBoxEnabled) {
         this.search(this.$autoCompleteBox.val());
       } else {
         this.search(this.$searchText.val());
       }
-    });
+    }, true, true);
 
     if (this.options.modeOptionsEnabled === false) {
       this.$modeOptions.hide();

--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -217,7 +217,7 @@ export class PagingHeaderPanel extends HeaderPanel<
     this.$search.append(this.$total);
 
     this.$searchButton = $(
-      `<a class="go btn btn-primary" tabindex="0">${this.content.go}</a>`
+      `<button class="go btn btn-primary" tabindex="0">${this.content.go}</button>`
     );
     this.$search.append(this.$searchButton);
 

--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -413,7 +413,7 @@ export class PagingHeaderPanel extends HeaderPanel<
       } else {
         this.search(this.$searchText.val());
       }
-    }, true, true);
+    });
 
     if (this.options.modeOptionsEnabled === false) {
       this.$modeOptions.hide();

--- a/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -195,7 +195,7 @@ export class PDFCenterPanel extends CenterPanel<
       }
 
       this._render(this._pageIndex);
-    }, true, true);
+    });
 
     this.onAccessibleClick(this._$zoomOutButton, () => {
       const newScale: number = this._scale - 0.5;
@@ -207,7 +207,7 @@ export class PDFCenterPanel extends CenterPanel<
       }
 
       this._render(this._pageIndex);
-    }, true, true);
+    });
   }
 
   disablePrevButton(): void {

--- a/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -185,9 +185,7 @@ export class PDFCenterPanel extends CenterPanel<
 
     this.disableNextButton();
 
-    this._$zoomInButton.onPressed((e: any) => {
-      e.preventDefault();
-
+    this.onAccessibleClick(this._$zoomInButton, () => {
       const newScale: number = this._scale + 0.5;
 
       if (newScale < this._maxScale) {
@@ -197,11 +195,9 @@ export class PDFCenterPanel extends CenterPanel<
       }
 
       this._render(this._pageIndex);
-    });
+    }, true, true);
 
-    this._$zoomOutButton.onPressed((e: any) => {
-      e.preventDefault();
-
+    this.onAccessibleClick(this._$zoomOutButton, () => {
       const newScale: number = this._scale - 0.5;
 
       if (newScale > this._minScale) {
@@ -211,7 +207,7 @@ export class PDFCenterPanel extends CenterPanel<
       }
 
       this._render(this._pageIndex);
-    });
+    }, true, true);
   }
 
   disablePrevButton(): void {

--- a/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -64,8 +64,8 @@ export class PDFCenterPanel extends CenterPanel<
         <span class="sr-only">${this.content.next}</span>
       </button>`
   );
-    this._$zoomInButton = $('<div class="btn zoomIn" tabindex="0"></div>');
-    this._$zoomOutButton = $('<div class="btn zoomOut" tabindex="0"></div>');
+    this._$zoomInButton = $('<button class="btn zoomIn" tabindex="0"></button>');
+    this._$zoomOutButton = $('<button class="btn zoomOut" tabindex="0"></button>');
 
     // Only attach PDF controls if we're using PDF.js; they have no meaning in
     // PDFObject. However, we still create the objects above so that references

--- a/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
@@ -138,9 +138,9 @@ export class PDFHeaderPanel extends HeaderPanel<
       $(this).select();
     });
 
-    this.$searchButton.onPressed(() => {
+    this.onAccessibleClick(this.$searchButton, () => {
       this.search(this.$searchText.val());
-    });
+    }, true, true);
   }
 
   render(): void {

--- a/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
@@ -140,7 +140,7 @@ export class PDFHeaderPanel extends HeaderPanel<
 
     this.onAccessibleClick(this.$searchButton, () => {
       this.search(this.$searchText.val());
-    }, true, true);
+    });
   }
 
   render(): void {

--- a/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
@@ -86,7 +86,7 @@ export class PDFHeaderPanel extends HeaderPanel<
     this.$search.append(this.$total);
 
     this.$searchButton = $(
-      '<a class="go btn btn-primary" tabindex="0">' + this.content.go + "</a>"
+      '<button class="go btn btn-primary" tabindex="0">' + this.content.go + "</button>"
     );
     this.$search.append(this.$searchButton);
     this.$searchButton.disable();

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -65,7 +65,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
 
     this.onAccessibleClick(this.$expandButton, () => {
       this.toggle();
-    }, true, true);
+    });
 
     this.$expandFullButton.on("click", () => {
       this.expandFull();
@@ -89,7 +89,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
       } else {
         this.toggle();
       }
-    }, true, true);
+    });
 
     this.$top.hide();
     this.$main.hide();

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -42,7 +42,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     }
 
     this.$collapseButton = $(
-      '<div role="button" class="collapseButton" tabindex="0"></div>'
+      '<button role="button" class="collapseButton" tabindex="0"></button>'
     );
     this.$collapseButton.prop("title", this.content.collapse);
     this.$top.append(this.$collapseButton);
@@ -51,7 +51,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     this.$element.append(this.$closed);
 
     this.$expandButton = $(
-      '<a role="button" class="expandButton" tabindex="0"></a>'
+      '<button role="button" class="expandButton" tabindex="0"></button>'
     );
     this.$expandButton.prop("title", this.content.expand);
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -65,7 +65,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
 
     this.onAccessibleClick(this.$expandButton, () => {
       this.toggle();
-    });
+    }, true, true);
 
     this.$expandFullButton.on("click", () => {
       this.expandFull();
@@ -89,7 +89,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
       } else {
         this.toggle();
       }
-    });
+    }, true, true);
 
     this.$top.hide();
     this.$main.hide();

--- a/src/content-handlers/iiif/modules/uv-shared-module/Panel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Panel.ts
@@ -37,7 +37,7 @@ export class Panel {
     el: JQuery,
     callback: (e: JQueryEventObject) => void,
     withClick = true,
-    anchorAsButton = false
+    treatAsButton = false
   ) {
 
     if (withClick) {
@@ -48,9 +48,9 @@ export class Panel {
 
     el.on("keydown", (e) => {
 
-      // by passing anchorAsButton as true this will become false
+      // by passing treatAsButton  as true this will become false
       // and so an anchor won't be excluded from Space presses
-      let isAnchor = e.target.nodeName === 'A' && !anchorAsButton;
+      let isAnchor = e.target.nodeName === 'A' && !treatAsButton;
 
       // 13 = Enter, 32 = Space
       if ((e.which === 32 && !isAnchor) || e.which === 13) {

--- a/src/content-handlers/iiif/modules/uv-shared-module/Panel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Panel.ts
@@ -36,18 +36,30 @@ export class Panel {
   onAccessibleClick(
     el: JQuery,
     callback: (e: JQueryEventObject) => void,
-    withClick = true
+    withClick = true,
+    anchorAsButton = false
   ) {
+
     if (withClick) {
       el.on("click", (e) => {
         callback(e);
       });
     }
-    el.on("keyup", (e) => {
-      if (e.keyCode === 32) {
+
+    el.on("keydown", (e) => {
+
+      // by passing anchorAsButton as true this will become false
+      // and so an anchor won't be excluded from Space presses
+      let isAnchor = e.target.nodeName === 'A' && !anchorAsButton;
+
+      // 13 = Enter, 32 = Space
+      if ((e.which === 32 && !isAnchor) || e.which === 13) {
+        // stops space scrolling the page
+        e.preventDefault();
         callback(e);
       }
     });
+
   }
 
   resize(): void {


### PR DESCRIPTION
Fixes #1084 
Fixes #1157 

All buttons and pseudo-buttons that previously weren't able to be activated via enter/spacebar should now be able to be.

I've modified Panel.ts:onAccessibleClick() to check whether the key is either enter or space and in the case of the latter, prevent the default action (scrolling the page). 

It also now has a fourth arg to specify whether an anchor should be treated as a button i.e. spacebar should activate it. This is for things like tabs where they're an anchor but work like a button.

Some elements that were `<div>` or `<a>` have been changed to `<button>`.

I've also made the thumbnails in the left panel work with space+enter, however the gallery view wasn't possible. For some reason you can't even focus inside it, but as it's the iiif-gallery-component I've not looked into it.