### PR TITLE
Fix inconsistent links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A community-developed open source project on a mission<br/> to help you share yo
 <a href="https://app.netlify.com/sites/uv/deploys">
 <img src="https://api.netlify.com/api/v1/badges/91dc58e8-49dd-495f-98bb-84570a0edb7c/deploy-status" />
 </a>
-<a href="https://github.com/UniversalViewer/universalviewer/blob/main/LICENSE.txt"><img src="https://camo.githubusercontent.com/e80e20b31b4af7da8580f68d415779d250eee229/68747470733a2f2f696d672e736869656c64732e696f2f6e706d2f6c2f74687265652e737667" alt="License" data-canonical-src="https://img.shields.io/npm/l/universalviewer.svg" style="max-width:100%;"></a>
+<a href="https://github.com/UniversalViewer/universalviewer/blob/dev/LICENSE.txt"><img src="https://camo.githubusercontent.com/e80e20b31b4af7da8580f68d415779d250eee229/68747470733a2f2f696d672e736869656c64732e696f2f6e706d2f6c2f74687265652e737667" alt="License" data-canonical-src="https://img.shields.io/npm/l/universalviewer.svg" style="max-width:100%;"></a>
 <a href="https://github.com/UniversalViewer/universalviewer/wiki">About</a>
 </p>
 
@@ -57,8 +57,8 @@ Read the technical [docs](https://docs.universalviewer.io/modules.html) to learn
 Read below to learn how to take part in improving the UV:
 
 - Fork the repository and [run the examples from source](#-getting-started)
-- Get familiar with [Code of Conduct](https://github.com/UniversalViewer/universalviewer/blob/main/CODE_OF_CONDUCT.md)
-- Read our [guide to contributing](https://github.com/UniversalViewer/universalviewer/blob/main/CONTRIBUTING.md)
+- Get familiar with [Code of Conduct](https://github.com/UniversalViewer/universalviewer/blob/dev/CODE_OF_CONDUCT.md)
+- Read our [guide to contributing](https://github.com/UniversalViewer/universalviewer/blob/dev/CONTRIBUTING.md)
 - Read our [governance document](https://github.com/UniversalViewer/universalviewer/blob/dev/GOVERNANCE.md) to learn more about roles and responsibilities, support, membership, and the decision making process.
 - Find an [issue](https://github.com/UniversalViewer/universalviewer/issues) to work on and submit a pull request
 - Could not find an issue? Look for bugs, typos, and missing features.
@@ -81,7 +81,7 @@ Read our [Accessibility Statement](https://github.com/UniversalViewer/universalv
 
 ## 📣 Feedback
 
-Read below how to engage with the UV [community](https://github.com/UniversalViewer/universalviewer/blob/main/COMMUNITY_TEAM.md):
+Read below how to engage with the UV [community](https://github.com/UniversalViewer/universalviewer/blob/dev/COMMUNITY_TEAM.md):
 
 - Join the discussion on [Slack](http://universalviewer.io/#contact).
 - Ask a question, request a new feature and file a bug with [GitHub issues](https://github.com/universalviewer/universalviewer/issues/new).


### PR DESCRIPTION
I noticed that some links in README were pointing to the dev branch while others were pointing to main. This led to some links pointing at outdated information. This PR adjusts everything to use dev links so the most current documentation is exposed.