### PR TITLE
Button normalization

### DIFF
--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
@@ -76,6 +76,10 @@
                         &.disabled {
                             background-image: data-uri('../img/right_arrow_disabled.png');
                         }
+
+                        & .uv-icon-next {
+                            background-image: none;
+                        }
                     }
 
                     &.next.vertical {
@@ -92,6 +96,13 @@
                                 background-image: data-uri('../img/up_arrow_disabled.png');
                             }
                         }
+                    }
+
+
+                    /* fixes out-of-scope iiif-tree and iiif-gallery icons */
+                    &.prev .uv-icon-prev,
+                    &.next .uv-icon-next {
+                        background-image: none;
                     }
                 }
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/scaffolding.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/scaffolding.less
@@ -50,6 +50,13 @@
     line-height: inherit;
   }
 
+  // Button normalization
+
+  button {
+    border: 0;
+    background-color: transparent;
+  }
+
   // Links
 
   a {


### PR DESCRIPTION
1. Buttons after merging [MediaPlayer PR](#1130) were missing normalization. Removed borders and background colors to fix this.
2. Seadragon next page buttons had intended and *bonus backgrounds* from iiif-tree and iiif-gallery. Added LESS to remove the free extras.