### PR TITLE
Improve documentation generation workflow.

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Build documentation
         run: npm run docs
 
-      - name: Regenerate CNAME file
-        run: echo docs.universalviewer.io > docs/CNAME
-
       - name: Auto-commit fixes
         uses: EndBug/add-and-commit@v9
         with:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build-es": "node ./esbuild.mjs",
     "build-tsc": "tsc --skipLibCheck --module CommonJS --esModuleInterop --declarationDir ./dist/cjs --declaration --outDir ./dist/cjs -p . && npm run copy-files",
     "copy-files": "copyfiles -u 1 src/**/*.svg dist/cjs && copyfiles -u 1 src/**/*.gif dist/cjs && copyfiles -u 1 src/**/*.less dist/cjs && copyfiles -u 1 src/extensions/**/*.less dist/cjs && copyfiles -u 1 src/**/*.css dist/cjs",
-    "docs": "typedoc --plugin typedoc-plugin-missing-exports --gitRevision dev",
+    "docs": "typedoc --plugin typedoc-plugin-missing-exports ; echo docs.universalviewer.io > docs/CNAME",
     "test": "jest",
     "prepublishOnly": "npm run build && npm run build-tsc && npm run build-es"
   },

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,4 +1,5 @@
 {
   "entryPoints": ["src/content-handlers/iiif/Docs.ts"],
+  "sourceLinkTemplate": "https://github.com/UniversalViewer/universalviewer/blob/dev/{path}#L{line}",
   "out": "docs"
 }


### PR DESCRIPTION
This PR fixes a problem that caused the GitHub action for documentation generation to change all of the documentation when documentation was built in a fork of the project. Documentation URLs are now hard-coded in a sourceLinkTemplate instead of inferred from the Git state. Additionally, regeneration of the CNAME document has been moved out of the workflow and into the package.json script, and configuration was moved out of the script and into the config file, all for greater consistency.