### PR TITLE
Remove unnecessary explicit dependency on @webpack-cli/serve.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "@types/node": "^22.9.0",
         "@types/react": "^18.0.3",
         "@types/react-dom": "^18.0.0",
-        "@webpack-cli/serve": "2.0.5",
         "async": "0.9.0",
         "chai": "5.1.2",
         "copy-webpack-plugin": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@types/node": "^22.9.0",
     "@types/react": "^18.0.3",
     "@types/react-dom": "^18.0.0",
-    "@webpack-cli/serve": "2.0.5",
     "async": "0.9.0",
     "chai": "5.1.2",
     "copy-webpack-plugin": "^12.0.2",


### PR DESCRIPTION
The [NPM page for @webpack-cli/serve](https://www.npmjs.com/package/@webpack-cli/serve) says: "This package is used by webpack-cli under-the-hood and is not intended for installation." Since it is included automatically by webpack-cli, we do not need to have a separate explicit dependency on it in package.json; this PR removes it to simplify dependency management. The change has no impact on functionality or which packages get installed.