### PR TITLE
Turn off home control by default.

### DIFF
--- a/src/uv-iiif-config.json
+++ b/src/uv-iiif-config.json
@@ -35,7 +35,7 @@
     "openSeadragonCenterPanel": {
       "options": {
         "autoHideControls": false,
-        "showHomeControl": true,
+        "showHomeControl": false,
         "showAdjustImageControl": true
       }
     },


### PR DESCRIPTION
Displaying the OSD home control is a configurable setting that has historically been off by default. PR #1052 fixed a bug related to the styling of the home button, but it also turned the button on by default, which was probably not desirable, as discussed in #1248.

This PR simply restores the default setting to its previous value, so that release 4.1.0 will behave the same as release 4.0.25.