### PR TITLE
Release Candidate: 4.1.0-rc2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - run: npm ci
+      - run: npm run build
 
       - uses: JS-DevTools/npm-publish@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
 
       - run: npm ci
-      - run: npm run build
+      - run: npm run prepublishOnly
 
       - uses: JS-DevTools/npm-publish@v3
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "universalviewer",
-  "version": "4.1.0-rc1",
+  "version": "4.1.0-rc2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "universalviewer",
-      "version": "4.1.0-rc1",
+      "version": "4.1.0-rc2",
       "license": "MIT",
       "dependencies": {
         "@edsilv/http-status-codes": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universalviewer",
-  "version": "4.1.0-rc1",
+  "version": "4.1.0-rc2",
   "description": "The Universal Viewer is a community-developed open source project on a mission to help you share your 📚📜📰📽️📻🗿 with the 🌎",
   "engines": {
     "node": ">=18",


### PR DESCRIPTION
This is a continuation of #1248. In addition to the changes in the first release candidate, this release also changes the default behavior of the home button (as discussed on the previous PR) and makes an adjustment to the GitHub Actions release workflow to correct a problem that led to an incomplete version of RC1 on NPM.

Normally, these small changes would not justify a second release candidate, but in this instance, the release was necessitated by the NPM publishing glitch.