### PR TITLE
added preferMediaElementExtension config option

### DIFF
--- a/src/content-handlers/iiif/BaseConfig.ts
+++ b/src/content-handlers/iiif/BaseConfig.ts
@@ -67,6 +67,9 @@ export type Options = {
   /** Determines if access control is pessimistic */
   pessimisticAccessControl?: boolean;
 
+  /** Determines if the mediaelement extension should be preferred */
+  preferMediaElementExtension?: boolean;
+
   /** Determines if viewport is preserved */
   preserveViewport?: boolean;
 
@@ -226,7 +229,7 @@ export type SettingsDialogueContent = DialogueContent & {
   clickToZoomEnabled: string;
   pagingEnabled: string;
   reducedMotion: string;
-  truncateThumbnailLabels: string; 
+  truncateThumbnailLabels: string;
   preserveViewport: string;
   title: string;
   website: string;

--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -386,9 +386,8 @@ export default class IIIFContentHandler extends BaseContentHandler<IIIFData>
       const hasRanges: boolean = helper.getRanges().length > 0;
 
       if (
-        (extension!.type === Extension.AV && !hasRanges) ||
-        (extension!.type === Extension.AV &&
-          data.config.options.preferMediaElementExtension)
+        extension!.type === Extension.AV &&
+        (!hasRanges || data.config.options.preferMediaElementExtension)
       ) {
         extension = await that._getExtensionByType(
           Extension.MEDIAELEMENT,

--- a/src/iiif-collection.json
+++ b/src/iiif-collection.json
@@ -905,6 +905,24 @@
       "visible": true,
       "manifests": [
         {
+          "@id": "https://iiif.io/api/cookbook/recipe/0002-mvm-audio/manifest.json",
+          "@type": "sc:Manifest",
+          "label": "Simplest Audio Example 1",
+          "visible": true
+        },
+        {
+          "@id": "https://iiif.io/api/cookbook/recipe/0003-mvm-video/manifest.json",
+          "@type": "sc:Manifest",
+          "label": "Simplest Video Example 3",
+          "visible": true
+        },
+        {
+          "@id": "https://iiif.io/api/cookbook/recipe/0064-opera-one-canvas/manifest.json",
+          "@type": "sc:Manifest",
+          "label": "Table of Contents for Multiple A/V Files on a Single Canvas",
+          "visible": true
+        },
+        {
           "@id": "https://edsilv.github.io/biiif-test-manifests/sound-manifest/index.json",
           "@type": "sc:Manifest",
           "label": "Somali Love Song (mp3)",
@@ -962,7 +980,7 @@
           "@id": "https://iiif-commons.github.io/iiif-av-component/examples/data/iiif/lunchroom-manners.json",
           "@type": "sc:Manifest",
           "label": "Lunchroom manners",
-          "visible": true
+          "visible": false
         },
         {
           "@id": "https://iiif-commons.github.io/iiif-av-component/examples/data/iiif/02.json",
@@ -1004,19 +1022,19 @@
           "@id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/loose-ends/C1685_98_P3.json",
           "@type": "sc:Manifest",
           "label": "Loose ends",
-          "visible": true
+          "visible": false
         },
         {
           "@id": "https://api-beta.bl.uk/metadata/iiif/ark:/81055/vdc_100061383968.0x000002/manifest.json",
           "@type": "sc:Manifest",
           "label": "BL AV Root Download",
-          "visible": true
+          "visible": false
         },
         {
           "@id": "https://edsilv.github.io/test-manifests/bl-av-download-rendering-ranges.json",
           "@type": "sc:Manifest",
           "label": "BL AV Ranges Download",
-          "visible": true
+          "visible": false
         },
         {
           "@id": "https://iiif-commons.github.io/iiif-av-component/examples/data/bl/sounds-tests/C1685_98_dash.json",

--- a/src/uv-iiif-config.json
+++ b/src/uv-iiif-config.json
@@ -7,6 +7,7 @@
     "limitLocales": false,
     "overrideFullScreen": false,
     "pagingEnabled": true,
+    "preferMediaElementExtension": false,
     "rightPanelEnabled": true,
     "clickToZoomEnabled": false,
     "saveUserSettings": true


### PR DESCRIPTION
It's now possible to use config to override which extensions get loaded depending on your use case. In this case, Exhibit only needs the simple AV experience even when manifests have structure.