### PR TITLE
Fix rotation control: ensure rotation value is a number.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -568,7 +568,7 @@
         };
 
         $iiif_setRotationButton.onclick = function() {
-          var rotation = $iiif_rotation.value;
+          var rotation = parseInt($iiif_rotation.value);
           uv.set({
             rotation: rotation,
           });


### PR DESCRIPTION
The example form's rotation control was causing strange behavior under some circumstances. Upon investigation, the root cause was the fact that we were passing a string type as if it were a number. Since index.html is not type checked, the compiler didn't catch the problem.

I chose to use `parseInt` on the assumption that we're not interested in fractional rotation values... but I imagine `parseFloat` might be worth considering if we want more granular control for some reason.