### PR TITLE
add/remove muted attribute

### DIFF
--- a/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
@@ -105,9 +105,15 @@ export class MediaElementCenterPanel extends CenterPanel<
       }
     });
 
-    this.extensionHost.subscribe(IIIFEvents.SET_MUTED, (muted) => {
+    this.extensionHost.subscribe(IIIFEvents.SET_MUTED, (muted: boolean) => {
       if (that.player) {
         that.player.setMuted(muted);
+
+        if (muted) {
+          that.$media.attr("muted", "");
+        } else {
+          that.$media.removeAttr("muted");
+        }
       }
     });
 
@@ -350,6 +356,22 @@ export class MediaElementCenterPanel extends CenterPanel<
               MediaElementExtensionEvents.MEDIA_TIME_UPDATE,
               Math.floor(mediaElement.currentTime)
             );
+          });
+
+          mediaElement.addEventListener("volumechange", (volume) => {
+            const muted: boolean = volume.detail.target.getMuted();
+
+            if (that.muted === false && muted === true) {
+              that.muted = true;
+              that.extensionHost.fire(MediaElementExtensionEvents.MEDIA_MUTED);
+            }
+
+            if (that.muted === true && muted === false) {
+              that.muted = false;
+              that.extensionHost.fire(
+                MediaElementExtensionEvents.MEDIA_UNMUTED
+              );
+            }
           });
         },
       });

--- a/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
@@ -108,12 +108,7 @@ export class MediaElementCenterPanel extends CenterPanel<
     this.extensionHost.subscribe(IIIFEvents.SET_MUTED, (muted: boolean) => {
       if (that.player) {
         that.player.setMuted(muted);
-
-        if (muted) {
-          that.$media.attr("muted", "");
-        } else {
-          that.$media.removeAttr("muted");
-        }
+        that.updateMutedAttribute(muted);
       }
     });
 
@@ -131,6 +126,14 @@ export class MediaElementCenterPanel extends CenterPanel<
     this.$wrapper.append(this.$container);
 
     this.title = this.extension.helper.getLabel();
+  }
+
+  updateMutedAttribute(muted: boolean) {
+    if (muted) {
+      this.$media.attr("muted", "");
+    } else {
+      this.$media.removeAttr("muted");
+    }
   }
 
   async openMedia(resources: IExternalResource[]) {
@@ -284,10 +287,13 @@ export class MediaElementCenterPanel extends CenterPanel<
 
             if (that.muted === true && muted === false) {
               that.muted = false;
+
               that.extensionHost.fire(
                 MediaElementExtensionEvents.MEDIA_UNMUTED
               );
             }
+
+            that.updateMutedAttribute(that.muted);
           });
         },
       });
@@ -372,6 +378,8 @@ export class MediaElementCenterPanel extends CenterPanel<
                 MediaElementExtensionEvents.MEDIA_UNMUTED
               );
             }
+
+            that.updateMutedAttribute(that.muted);
           });
         },
       });


### PR DESCRIPTION
Unless the attribute is actually on the element, the browser doesn't recognise it as muted and won't autoplay. Also added missing volumechange handler to audio