### PR TITLE
Release candidate: 4.1.0-rc8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "universalviewer",
-  "version": "4.1.0-rc7",
+  "version": "4.1.0-rc8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "universalviewer",
-      "version": "4.1.0-rc7",
+      "version": "4.1.0-rc8",
       "license": "MIT",
       "dependencies": {
         "@edsilv/http-status-codes": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universalviewer",
-  "version": "4.1.0-rc7",
+  "version": "4.1.0-rc8",
   "description": "The Universal Viewer is a community-developed open source project on a mission to help you share your 📚📜📰📽️📻🗿 with the 🌎",
   "engines": {
     "node": ">=18",


### PR DESCRIPTION
This builds on #1281 with more AV fixes and an integration update needed for @edsilv's Exhibit project.

No further changes are expected unless more bugs are found; a release is planned for Tuesday, January 21.