### PR TITLE
Fix dynamic styling mechanism

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/css/lg.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/lg.less
@@ -10,4 +10,33 @@
 
         }
     }
+
+    .lg-mediaquery({
+        .headerPanel {
+            display: block;
+            visibility: visible;
+        }
+
+        .mainPanel {
+            .leftPanel {
+                display: block;
+                visibility: visible;
+            }
+
+            .rightPanel {
+                display: block;
+                visibility: visible;
+            }
+        }
+
+        .footerPanel {
+            display: block;
+            visibility: visible;
+        }
+
+        .mobileFooterPanel {
+            display: none;
+            visibility: hidden;
+        }
+    })
 }

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/md.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/md.less
@@ -11,4 +11,33 @@
 
     }
 
+    .md-mediaquery({
+        .headerPanel {
+            display: block;
+            visibility: visible;
+        }
+
+        .mainPanel {
+            .leftPanel {
+                display: block;
+                visibility: visible;
+            }
+
+            .rightPanel {
+                display: block;
+                visibility: visible;
+            }
+        }
+
+        .footerPanel {
+            display: block;
+            visibility: visible;
+        }
+
+        .mobileFooterPanel {
+            display: none;
+            visibility: hidden;
+        }
+    })
+
 }

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/mixins-extended.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/mixins-extended.less
@@ -26,26 +26,6 @@
     }
 }
 
-.only-desktop() {
-    display: var(--uv-desktop-display, none);
-    visibility: var(--uv-desktop-visibility, hidden);
-}
-
-.only-mobile() {
-    display: var(--uv-mobile-display, block);
-    visibility: var(--uv-mobile-visibility, visible);
-}
-
-:root {
-    .md-mediaquery({
-        --uv-mobile-display: none;
-        --uv-mobile-visibility: hidden;
-
-        --uv-desktop-display: block;
-        --uv-desktop-visibility: visible;
-    });
-}
-
 
 // end media queries
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/right-panel.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/right-panel.less
@@ -4,6 +4,8 @@
 
     .rightPanel {
 
+        width: 70px;
+
         z-index: 10;
 
         .top {

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/right-panel.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/right-panel.less
@@ -4,8 +4,6 @@
 
     .rightPanel {
 
-        width: 70px;
-
         z-index: 10;
 
         .top {

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/sm.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/sm.less
@@ -10,4 +10,32 @@
         }
     }
 
+    .sm-mediaquery({
+        .headerPanel {
+            display: none;
+            visibility: hidden;
+        }
+
+        .mainPanel {
+            .leftPanel {
+                display: none;
+                visibility: hidden;
+            }
+
+            .rightPanel {
+                display: none;
+                visibility: hidden;
+            }
+        }
+
+        .footerPanel {
+            display: none;
+            visibility: hidden;
+        }
+
+        .mobileFooterPanel {
+            display: block;
+            visibility: visible;
+        }
+    })
 }

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/xl.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/xl.less
@@ -1,5 +1,4 @@
 .uv {
-
     #debug {
         #xl {
             .xl-mediaquery({

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/xl.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/xl.less
@@ -1,4 +1,5 @@
 .uv {
+
     #debug {
         #xl {
             .xl-mediaquery({
@@ -8,25 +9,32 @@
         }
     }
 
-    .headerPanel {
-        .only-desktop();
-    }
-
-    .mainPanel {
-        .leftPanel {
-            .only-desktop();
+    .xl-mediaquery({
+        .headerPanel {
+            display: block;
+            visibility: visible;
         }
 
-        .rightPanel {
-            .only-desktop();
+        .mainPanel {
+            .leftPanel {
+                display: block;
+                visibility: visible;
+            }
+
+            .rightPanel {
+                display: block;
+                visibility: visible;
+            }
         }
-    }
 
-    .footerPanel {
-        .only-desktop();
-    }
+        .footerPanel {
+            display: block;
+            visibility: visible;
+        }
 
-    .mobileFooterPanel {
-        .only-mobile();
-    }
+        .mobileFooterPanel {
+            display: none;
+            visibility: hidden;
+        }
+    })
 }


### PR DESCRIPTION
TL;DR: UV wasn't actually picking up styling depending on sm, m, lg, xl screen sizes; panels were appearing/disappearing based on a fall-back default value.

This PR cleans up and enables the mechanism for styling based on small, medium, large, and extra large screen sizes that are defined in variables.less. Previously, this sizing system wasn't actually being activated. Because none of sm, md, lg, or xl.less had media queries checking for those sizes, only the last one to be imported in styles.less was being applied (xl.less). XL defined the visibility with the mobile only/desktop only mixins, but these relied on variables that were only defined if the medium media query was activated in this block of mixins-extended.less:

```
:root {
    .md-mediaquery({
        --uv-mobile-display: none;
        --uv-mobile-visibility: hidden;

        --uv-desktop-display: block;
        --uv-desktop-visibility: visible;
    });
}
```

As this was wrapped in a media query, these variables were only defined if the screen was medium or above! At size small, they weren't defined and so this

```
.only-desktop() {
    display: var(--uv-desktop-display, none);
    visibility: var(--uv-desktop-visibility, hidden);
}
```

defaulted to none and hidden, which was applied to the panels. So, the panels did indeed disappear at the small size, but not via the system that seemed to be intended by the sm, m, lg, and xl.less files. This sounds pretty convoluted, would be happy to demonstrate with dev tools if needed. 

This PR cleans this all up a bit and (I hope) makes it a bit more comprehensible as we move on to working on the mobile view. It lets our mobile view (sm) for the panels be styled either in the sm.less, or the panel css file via a media query. This is just a suggestion for a simpler system, but I'm open to suggestions to other ways to organize it.

This PR shouldn't change the current behaviour of UV at different sizes. I've done some manual testing but can give it a more thorough test tomorrow morning. I am wondering if there was a good reason it was done in the hacky way before that will become apparent with further testing. Maybe @crhallberg would be a good person to look at this to see if what I've done makes sense.