### PR TITLE
fixed urls for these locales

### DIFF
--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -120,7 +120,7 @@
   "$reducedMotion": "Réduire le mouvement (désactive les animations)",
   "$truncateThumbnailLabels": "Tronquer les onglets",
   "$preserveViewport": "Conserver le zoom",
-  "$uvWebsite": "<a href='https://github.com/universalviewer/universalviewer#contributors'>En savoir + sur le Universal Viewer</a>",
+  "$uvWebsite": "<a href='https://github.com/universalviewer/universalviewer>En savoir + sur le Universal Viewer</a>",
   "$custom": "personnalisée",
   "$embedInstructions": "Pour afficher ce contenu sur votre site internet, copier-collez le code ci-dessous.",
   "$height": "Hauteur",

--- a/src/locales/pl-PL.json
+++ b/src/locales/pl-PL.json
@@ -120,7 +120,7 @@
   "$reducedMotion": "Zmniejsz ruch (wyłącza animacje)",
   "$truncateThumbnailLabels": "Skróć etykiety miniatur",
   "$preserveViewport": "Zachowanie przybliżenia",
-  "$uvWebsite": "<a href='https://github.com/universalviewer/universalviewer#contributors'>Więcej informacji o Universal Viewer</a>",
+  "$uvWebsite": "<a href='https://github.com/universalviewer/universalviewer'>Więcej informacji o Universal Viewer</a>",
   "$custom": "Ustawienia",
   "$embedInstructions": "Aby osadzić ten obiekt na własnej witrynie, skopiuj i wklej poniższy kod.",
   "$height": "Wysokość",

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -120,7 +120,7 @@
   "$reducedMotion": "Minska rörelse (inaktiverar animationer)",
   "$truncateThumbnailLabels": "Förkorta miniatyrtext",
   "$preserveViewport": "Behåll zoomnivå",
-  "$uvWebsite": "<a href='https://github.com/universalviewer/universalviewer#contributors'>Mer information om Universal Viewer</a>",
+  "$uvWebsite": "<a href='https://github.com/universalviewer/universalviewer'>Mer information om Universal Viewer</a>",
   "$custom": "Anpassad",
   "$embedInstructions": "För att bädda in det här objektet i din egen webbplats, kopiera och klistra koden nedan.",
   "$height": "Höjd",


### PR DESCRIPTION
On our tech call with @crhallberg, @demiankatz and @jamesmisson  we noticed these 3 locale urls had an incorrect _#contributors_ appended. So I created a quick PR to fix that. Fortunately the "more info" link is already configured by locale so we should be able to work on the updated url content independently.