### PR TITLE
Preliminary sidebar handling css

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A community-developed open source project on a mission<br/> to help you share yo
 </a>
 </p>
 <p align="center"><a href="https://docs.google.com/forms/d/e/1FAIpQLSeHLD0kng5aXvGFsNN_tJGsZMTnp08Hv2F6kdGsJRb6bT0NWw/viewform" rel="nofollow"><strong>#</strong> Slack
-</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://x.com/universalviewer"> <strong>@</strong> X</a> &nbsp;&nbsp;&nbsp;&nbsp; <a href="https://github.com/UniversalViewer/universalviewer/wiki"> About </a> </p>
+</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://bsky.app/profile/universalviewer.io"> <strong>@</strong> Bluesky</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://x.com/universalviewer"> <strong>@</strong> X</a> &nbsp;&nbsp;&nbsp;&nbsp; <a href="https://github.com/UniversalViewer/universalviewer/wiki"> About </a> </p>
 
 <br/>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@ A community-developed open source project on a mission<br/> to help you share yo
 </a>
 </p>
 <p align="center"><a href="https://docs.google.com/forms/d/e/1FAIpQLSeHLD0kng5aXvGFsNN_tJGsZMTnp08Hv2F6kdGsJRb6bT0NWw/viewform" rel="nofollow"><strong>#</strong> Slack
-</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://x.com/universalviewer"> <strong>@</strong> X</a> &nbsp;&nbsp;&nbsp;&nbsp; <a href="https://github.com/UniversalViewer/universalviewer/wiki"> About </a> </p>
+</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://bsky.app/profile/universalviewer.io"> <strong>@</strong> Bluesky</a> &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://x.com/universalviewer"> <strong>@</strong> X</a> &nbsp;&nbsp;&nbsp;&nbsp; <a href="https://github.com/UniversalViewer/universalviewer/wiki"> About </a> </p>
 <br/>
 <pre><code>npm install universalviewer --save
 </code></pre>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@edsilv/http-status-codes": "1.0.3",
         "@edsilv/key-codes": "1.0.0",
         "@edsilv/utils": "^1.0.2",
-        "@google/model-viewer": "^1.9.2",
+        "@google/model-viewer": "^4.0.0",
         "@iiif/base-component": "2.0.1",
         "@iiif/iiif-av-component": "1.2.4",
         "@iiif/iiif-gallery-component": "^1.1.22",
@@ -792,15 +792,19 @@
       }
     },
     "node_modules/@google/model-viewer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@google/model-viewer/-/model-viewer-1.12.1.tgz",
-      "integrity": "sha512-GOf/By81rbxSmwWRVxBtlY5b3050msJ+BDWqonPj7M0/I7rNS/vVNjbLxTofbGjZObS3n0ELHj8TZ47UtkZbtg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google/model-viewer/-/model-viewer-4.0.0.tgz",
+      "integrity": "sha512-hf4mixP178gGtvWQq97a0uULr7k98BwJGRU3lvt12XnurOdLmZA/RPdW4tPsINNNQxZvmvQsjud4lZWre6WGNw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "lit": "^2.2.3",
-        "three": "^0.139.2"
+        "@monogrid/gainmap-js": "^3.0.1",
+        "lit": "^2.7.2"
       },
       "engines": {
         "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "three": "^0.169.0"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -1520,10 +1524,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.3.0.tgz",
+      "integrity": "sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@lit/reactive-element": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.5.0.tgz",
-      "integrity": "sha512-fQh9FDK0LPTwDk+0HhSZEtb8K0LTN1wXerwpGrWA+a8tWulYRDLI4vQDWp4GOIsewn0572KYV/oZ3+492D7osA=="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
@@ -1570,6 +1584,18 @@
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.1.0.tgz",
+      "integrity": "sha512-Obb0/gEd/HReTlg8ttaYk+0m62gQJmCblMOjHSMHRrBP2zdfKMHLCRbh/6ex9fSUJMKdjjIEiohwkbGD3wj2Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -2284,9 +2310,10 @@
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -7215,6 +7242,12 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -8518,28 +8551,32 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.5.0.tgz",
-      "integrity": "sha512-DtnUP6vR3l4Q8nRPPNBD+UxbAhwJPeky+OVbi3pdgMqm0g57xFSl1Sj64D1rIB+nVNdiVVg8YxB0hqKjvdadZA==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^1.5.0",
-        "lit-element": "^3.2.0",
-        "lit-html": "^2.5.0"
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
-      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
         "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.2.0"
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.5.0.tgz",
-      "integrity": "sha512-bLHosg1XL3JRUcKdSVI0sLCs0y1wWrj2sqqAN3cZ7bDDPNgmDHH29RV48x6Wz3ZmkxIupaE+z7uXSZ/pXWAO1g==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -10242,6 +10279,16 @@
       "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "dependencies": {
         "asap": "~2.0.6"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prompts": {
@@ -12206,11 +12253,6 @@
       "version": "8.10.66",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
       "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
-    },
-    "node_modules/three": {
-      "version": "0.139.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.139.2.tgz",
-      "integrity": "sha512-gV7q7QY8rogu7HLFZR9cWnOQAUedUhu2WXAnpr2kdXZP9YDKsG/0ychwQvWkZN5PlNw9mv5MoCTin6zNTXoONg=="
     },
     "node_modules/threejs-meshline": {
       "version": "2.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -764,16 +764,401 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.52.tgz",
       "integrity": "sha512-2RbW7WXeLex6RI+kQSxq6Ym0GiVcODeQ4Km7MnnTX5BHdOGQnqVa+s6AUmAW+OFYAJ8wv9QxvNZXm7/kBdGTVw=="
     },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
-      "integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -5122,10 +5507,11 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
-      "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5133,30 +5519,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.0",
-        "@esbuild/android-arm": "0.24.0",
-        "@esbuild/android-arm64": "0.24.0",
-        "@esbuild/android-x64": "0.24.0",
-        "@esbuild/darwin-arm64": "0.24.0",
-        "@esbuild/darwin-x64": "0.24.0",
-        "@esbuild/freebsd-arm64": "0.24.0",
-        "@esbuild/freebsd-x64": "0.24.0",
-        "@esbuild/linux-arm": "0.24.0",
-        "@esbuild/linux-arm64": "0.24.0",
-        "@esbuild/linux-ia32": "0.24.0",
-        "@esbuild/linux-loong64": "0.24.0",
-        "@esbuild/linux-mips64el": "0.24.0",
-        "@esbuild/linux-ppc64": "0.24.0",
-        "@esbuild/linux-riscv64": "0.24.0",
-        "@esbuild/linux-s390x": "0.24.0",
-        "@esbuild/linux-x64": "0.24.0",
-        "@esbuild/netbsd-x64": "0.24.0",
-        "@esbuild/openbsd-arm64": "0.24.0",
-        "@esbuild/openbsd-x64": "0.24.0",
-        "@esbuild/sunos-x64": "0.24.0",
-        "@esbuild/win32-arm64": "0.24.0",
-        "@esbuild/win32-ia32": "0.24.0",
-        "@esbuild/win32-x64": "0.24.0"
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
       }
     },
     "node_modules/esbuild-plugin-less": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^5.0.1",
         "file-loader": "^6.2.0",
-        "html-webpack-plugin": "5.6.0",
+        "html-webpack-plugin": "5.6.3",
         "jest": "^29",
         "jest-puppeteer": "^10",
         "less": "4.1.2",
@@ -6614,9 +6614,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.3.tgz",
+      "integrity": "sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^5.0.1",
     "file-loader": "^6.2.0",
-    "html-webpack-plugin": "5.6.0",
+    "html-webpack-plugin": "5.6.3",
     "jest": "^29",
     "jest-puppeteer": "^10",
     "less": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@edsilv/http-status-codes": "1.0.3",
     "@edsilv/key-codes": "1.0.0",
     "@edsilv/utils": "^1.0.2",
-    "@google/model-viewer": "^1.9.2",
+    "@google/model-viewer": "^4.0.0",
     "@iiif/base-component": "2.0.1",
     "@iiif/iiif-av-component": "1.2.4",
     "@iiif/iiif-gallery-component": "^1.1.22",

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
@@ -207,8 +207,8 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
     );
 
     this.extensionHost.subscribe(IIIFEvents.LEFTPANEL_EXPAND_FULL_START, () => {
-      this.shell.$centerPanel.hide();
-      this.shell.$rightPanel.hide();
+      /* this.shell.$centerPanel.hide();
+      this.shell.$rightPanel.hide(); */
     });
 
     this.extensionHost.subscribe(IIIFEvents.MINUS, () => {

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -173,19 +173,33 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
   }
 
   expandFull(): void {
-    if (!this.isExpanded) {
-      this.toggled();
-    }
+
+    console.log("BaseExpandPanel.ts:expandFull()");
 
     const settings = this.extension.getSettings();
     let isReducedAnimation = settings.reducedAnimation;
 
-    var targetWidth: number = this.getFullTargetWidth();
-    var targetLeft: number = this.getFullTargetLeft();
+    /* var targetWidth: number = this.getFullTargetWidth();
+    var targetLeft: number = this.getFullTargetLeft(); */
 
     this.expandFullStart();
 
     if (isReducedAnimation) {
+      if (!this.isExpanded) {
+        this.toggled();
+      }
+      this.expandFullFinish();
+    } else {
+      setTimeout(() => {
+        if (!this.isExpanded) {
+          this.toggled();
+        }
+        this.expandFullFinish();
+      }, 550);
+    }
+
+
+    /* if (isReducedAnimation) {
       this.$element.css("width", targetWidth);
       this.$element.css("left", targetLeft);
       this.expandFullFinish();
@@ -200,7 +214,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
           this.expandFullFinish();
         }
       );
-    }
+    } */
   }
 
   collapseFull(): void {
@@ -246,7 +260,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     return 0;
   }
 
-  toggleStart(): void {}
+  toggleStart(): void { }
 
   toggleFinish(): void {
     if (this.isExpanded && !this.autoToggled) {
@@ -256,14 +270,14 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     }
   }
 
-  expandFullStart(): void {}
+  expandFullStart(): void { }
 
   expandFullFinish(): void {
     this.isFullyExpanded = true;
     this.$expandFullButton.hide();
   }
 
-  collapseFullStart(): void {}
+  collapseFullStart(): void { }
 
   collapseFullFinish(): void {
     this.isFullyExpanded = false;

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -173,7 +173,6 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
   }
 
   expandFull(): void {
-
     console.log("BaseExpandPanel.ts:expandFull()");
 
     const settings = this.extension.getSettings();
@@ -197,7 +196,6 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
         this.expandFullFinish();
       }, 550);
     }
-
 
     /* if (isReducedAnimation) {
       this.$element.css("width", targetWidth);
@@ -260,7 +258,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     return 0;
   }
 
-  toggleStart(): void { }
+  toggleStart(): void {}
 
   toggleFinish(): void {
     if (this.isExpanded && !this.autoToggled) {
@@ -270,14 +268,14 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     }
   }
 
-  expandFullStart(): void { }
+  expandFullStart(): void {}
 
   expandFullFinish(): void {
     this.isFullyExpanded = true;
     this.$expandFullButton.hide();
   }
 
-  collapseFullStart(): void { }
+  collapseFullStart(): void {}
 
   collapseFullFinish(): void {
     this.isFullyExpanded = false;

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -108,6 +108,8 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
 
     autoToggled ? (this.autoToggled = true) : (this.autoToggled = false);
 
+    this.$element.toggleClass('open');
+
     // if collapsing, hide contents immediately.
     if (this.isExpanded) {
       this.$top.attr("aria-hidden", "true");
@@ -118,7 +120,19 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
       this.$closed.show();
     }
 
+    // to allow for the css transition to finish
+    // TODO: get this var from config and make sure css uses the same
+    // although make sure it is +50 to allow for lag
+    // and re-introduce the animation check
     if (isReducedAnimation) {
+      this.toggled();
+    } else {
+      setTimeout(() => {
+        this.toggled();
+      }, 300);
+    }
+
+    /* if (isReducedAnimation) {
       // This is reduced motion.
       this.$element.css("width", this.getTargetWidth());
       this.$element.css("left", this.getTargetLeft());
@@ -135,7 +149,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
           this.toggled();
         }
       );
-    }
+    } */
   }
 
   toggled(): void {

--- a/src/content-handlers/iiif/modules/uv-shared-module/LeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/LeftPanel.ts
@@ -77,4 +77,27 @@ export class LeftPanel<
 
     super.toggle(autoToggled);
   }
+
+  expandFull(): void {
+    console.log("LeftPanel.ts:expandFull()");
+
+    this.$element.parent().addClass('leftPanelOpenFull');
+    super.expandFull();
+  }
+
+  collapseFull(): void {
+    console.log("LeftPanel.ts:collapseFull()");
+
+    this.$element.parent().removeClass('leftPanelOpenFull');
+
+    // need this because 'closing' full width shouldn't actually do that
+    // if puts the left panel back to normal open state
+    // but if the left panel was previously closed, this class won't be present
+    // so we put it back
+    if (!this.$element.parent().hasClass("leftPanelOpen")) {
+      this.$element.parent().addClass("leftPanelOpen");
+    }
+
+    super.collapseFull();
+  }
 }

--- a/src/content-handlers/iiif/modules/uv-shared-module/LeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/LeftPanel.ts
@@ -81,14 +81,14 @@ export class LeftPanel<
   expandFull(): void {
     console.log("LeftPanel.ts:expandFull()");
 
-    this.$element.parent().addClass('leftPanelOpenFull');
+    this.$element.parent().addClass("leftPanelOpenFull");
     super.expandFull();
   }
 
   collapseFull(): void {
     console.log("LeftPanel.ts:collapseFull()");
 
-    this.$element.parent().removeClass('leftPanelOpenFull');
+    this.$element.parent().removeClass("leftPanelOpenFull");
 
     // need this because 'closing' full width shouldn't actually do that
     // if puts the left panel back to normal open state

--- a/src/content-handlers/iiif/modules/uv-shared-module/LeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/LeftPanel.ts
@@ -67,4 +67,14 @@ export class LeftPanel<
       this.$element.width(this.$element.parent().width());
     }
   }
+
+  toggle(autoToggled?: boolean): void {
+    if (this.isExpanded) {
+      this.$element.parent().removeClass('leftPanelOpen');
+    } else {
+      this.$element.parent().addClass('leftPanelOpen');
+    }
+
+    super.toggle(autoToggled);
+  }
 }

--- a/src/content-handlers/iiif/modules/uv-shared-module/RightPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/RightPanel.ts
@@ -66,4 +66,14 @@ export class RightPanel<T extends ExpandPanel> extends BaseExpandPanel<T> {
       ),
     });
   }
+
+  toggle(autoToggled?: boolean): void {
+    if (this.isExpanded) {
+      this.$element.parent().removeClass('rightPanelOpen');
+    } else {
+      this.$element.parent().addClass('rightPanelOpen');
+    }
+
+    super.toggle(autoToggled);
+  }
 }

--- a/src/content-handlers/iiif/modules/uv-shared-module/RightPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/RightPanel.ts
@@ -76,4 +76,8 @@ export class RightPanel<T extends ExpandPanel> extends BaseExpandPanel<T> {
 
     super.toggle(autoToggled);
   }
+
+  expandFull(): void {
+    super.expandFull();
+  }
 }

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/catch-all.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/catch-all.less
@@ -4,7 +4,7 @@
         .hidden();
     }
 
-    .mainPanel {
+    /* .mainPanel {
 
         .leftPanel {
             .hidden();
@@ -13,7 +13,7 @@
         .rightPanel {
             .hidden();
         }
-    }
+    } */
 
     .footerPanel {
         .hidden();

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/sm.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/sm.less
@@ -16,7 +16,7 @@
             visibility: hidden;
         }
 
-        .mainPanel {
+        /* .mainPanel {
             .leftPanel {
                 display: none;
                 visibility: hidden;
@@ -26,7 +26,7 @@
                 display: none;
                 visibility: hidden;
             }
-        }
+        } */
 
         .footerPanel {
             display: none;

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
@@ -18,6 +18,9 @@
 @import 'lg';
 @import 'xl';
 
+:root {
+    --uv-animation: 1;
+}
 
 .hidden {
     .hidden();
@@ -102,32 +105,56 @@
 
     .mainPanel {
 
+        // TODO: set these at runtime in html element style attr by getting from config?
+        --uv-grid-left-width-open: 271px;
+        --uv-grid-right-width-open: 271px;
+
+        --uv-grid-left-width: 30px;
+        --uv-grid-right-width: 30px;
+
         background: red;
+        margin: 0;
+        padding: 0;
+        
+        overflow: hidden;
 
-        .lg-mediaquery({
+        .md-mediaquery({
             background: maroon;
-
+            padding: 0.5rem;
             display: grid;
-            grid-template-columns: [left] minmax(25%, 255px) [center] 1fr [right] minmax(25%, 255px);
+            grid-template-columns: 
+                [left] var(--uv-grid-left-width) 
+                [center] minmax(0, 1fr)
+                [right] var(--uv-grid-right-width);
             grid-template-areas: "left center right";
-            //gap: 10px;
+
+            transition:all calc(var(--uv-animation) * 250ms) ease-in-out;
         });
+    }
+
+    .mainPanel.leftPanelOpen {
+        --uv-grid-left-width: var(--uv-grid-left-width-open);
+    }
+
+    .mainPanel.rightPanelOpen {
+        --uv-grid-right-width: var(--uv-grid-right-width-open);
     }
 
     .centerPanel {
         position: absolute;
+        overflow: hidden;
     }
 
     .centerPanel {
         width: 100% !important;
         left: auto !important;
         
-        background: yellow;
+        background: darkcyan;
 
-        .lg-mediaquery({
-            background: wheat;
+        .md-mediaquery({
+            background: darkolivegreen;
 
-            z-index: 12;
+            z-index: 15;
             grid-area: center;
         });
     }
@@ -138,44 +165,85 @@
         border: @panel-border;
     }
 
-    .leftPanel {
-        background: pink;
-        
-        position: relative;
-        width: auto !important;
-        height: auto !important;
-
-        .lg-mediaquery({
-            background: fuchsia;
-
-            grid-area: left;
-            z-index: 10;
-            position: absolute;
-            top: 0.625rem !important;
-            right: 0.625rem !important;
-            bottom: 0.625rem !important;
-            left: 0.625rem !important;
-        });
-    }
-
     .rightPanel {
         position: absolute;
         background: @panel-dark-bg;
         border: @panel-border;
     }
 
-    .rightPanel {
-        background: lime;
-        z-index: 11;
-        grid-area: right;
+    .leftPanel, .rightPanel {
+        overflow: hidden;
+        z-index: 20;
+        /* display: none; */
+        
+        transition:all calc(var(--uv-animation) * 250ms) ease-in-out;
+
+        position: absolute;
+        top: 2em !important;
+        right: 0em !important;
+        bottom: 2em !important;
+        left: 0em !important;
 
         width: auto !important;
         height: auto !important;
-        position: absolute;
-        top: 0.625rem !important;
-        right: 0.625rem !important;
-        bottom: 0.625rem !important;
-        left: 0.625rem !important;
+
+        .md-mediaquery({
+            display: block !important;
+            position: relative;
+
+            top: 0rem !important;
+            right: 0rem !important;
+            bottom: 0rem !important;
+            left: 0rem !important;
+        });
+
+        &.open {
+            display: block;
+        }
+    }
+
+    .leftPanel {
+        background: pink;
+        transform: translateX(calc(-100% + 30px));
+
+        .md-mediaquery({
+            background: fuchsia;
+            grid-area: left;
+            transform: none;
+        });
+    }
+
+    .leftPanel.open {
+        left: 0 !important;
+        right: 3em !important;
+        transform: none;
+
+        .md-mediaquery({
+            left: initial !important;
+            right: initial !important;
+        });
+    }
+
+    .rightPanel {
+        background: lime;
+        transform: translateX(calc(100% - 30px));
+        
+        .md-mediaquery({
+            background: yellowgreen;
+            grid-area: right;
+            transform: none;
+        });
+    }
+
+    .rightPanel.open {
+        right: 0 !important;
+        left: 3em !important;
+        transform: none;
+
+        .md-mediaquery({
+            left: initial !important;
+            right: initial !important;
+        });
     }
 
     .footerPanel {

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
@@ -100,20 +100,82 @@
         background: @body-bg; // important, otherwise you see two spinners
     }
 
-    .leftPanel {
-        position: absolute;
-        background: @panel-dark-bg;
-        border: @panel-border;
+    .mainPanel {
+
+        background: red;
+
+        .lg-mediaquery({
+            background: maroon;
+
+            display: grid;
+            grid-template-columns: [left] minmax(25%, 255px) [center] 1fr [right] minmax(25%, 255px);
+            grid-template-areas: "left center right";
+            //gap: 10px;
+        });
     }
 
     .centerPanel {
         position: absolute;
     }
 
+    .centerPanel {
+        width: 100% !important;
+        left: auto !important;
+        
+        background: yellow;
+
+        .lg-mediaquery({
+            background: wheat;
+
+            z-index: 12;
+            grid-area: center;
+        });
+    }
+
+    .leftPanel {
+        position: absolute;
+        background: @panel-dark-bg;
+        border: @panel-border;
+    }
+
+    .leftPanel {
+        background: pink;
+        
+        position: relative;
+        width: auto !important;
+        height: auto !important;
+
+        .lg-mediaquery({
+            background: fuchsia;
+
+            grid-area: left;
+            z-index: 10;
+            position: absolute;
+            top: 0.625rem !important;
+            right: 0.625rem !important;
+            bottom: 0.625rem !important;
+            left: 0.625rem !important;
+        });
+    }
+
     .rightPanel {
         position: absolute;
         background: @panel-dark-bg;
         border: @panel-border;
+    }
+
+    .rightPanel {
+        background: lime;
+        z-index: 11;
+        grid-area: right;
+
+        width: auto !important;
+        height: auto !important;
+        position: absolute;
+        top: 0.625rem !important;
+        right: 0.625rem !important;
+        bottom: 0.625rem !important;
+        left: 0.625rem !important;
     }
 
     .footerPanel {

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
@@ -19,12 +19,14 @@
 @import 'xl';
 
 :root {
+    // TODO: set these at runtime in html element style attr by getting from config?
     --uv-animation: 1;
 
     --uv-grid-left-width-open: 271px;
     --uv-grid-right-width-open: 271px;
 
     --uv-grid-left-width: 30px;
+    --uv-grid-main-width: minmax(0, 1fr);
     --uv-grid-right-width: 30px;
 }
 
@@ -110,23 +112,17 @@
     }
 
     .mainPanel {
-
-        // TODO: set these at runtime in html element style attr by getting from config?
-        
-
-        background: red;
         margin: 0;
         padding: 0;
         
         overflow: hidden;
 
         .md-mediaquery({
-            background: maroon;
             padding: 0.5rem;
             display: grid;
             grid-template-columns: 
                 [left] var(--uv-grid-left-width) 
-                [center] minmax(0, 1fr)
+                [center] var(--uv-grid-main-width)
                 [right] var(--uv-grid-right-width);
             grid-template-areas: "left center right";
 
@@ -142,6 +138,14 @@
         --uv-grid-right-width: var(--uv-grid-right-width-open);
     }
 
+    .mainPanel.leftPanelOpenFull {
+        --uv-grid-left-width: 100%;
+        --uv-grid-main-width: 0;
+        --uv-grid-right-width: 0;
+
+        transition-duration: calc(var(--uv-animation) * 500ms);
+    }
+
     .centerPanel {
         position: absolute;
         overflow: hidden;
@@ -150,12 +154,8 @@
     .centerPanel {
         width: 100% !important;
         left: auto !important;
-        
-        background: darkcyan;
 
         .md-mediaquery({
-            background: darkolivegreen;
-
             z-index: 15;
             grid-area: center;
         });
@@ -199,17 +199,35 @@
             left: 0rem !important;
         });
 
+        /* .top {
+            display: none;
+        }
+        .closed {
+            display: block;
+        }
+        .main {
+            display: none;
+        } */
+
         &.open {
             display: block;
+
+            /* .top {
+                display: block;
+            }
+            .closed {
+                display: none;
+            }
+            .main {
+                display: block;
+            } */
         }
     }
 
     .leftPanel {
-        background: pink;
         transform: translateX(calc(-100% + 30px));
 
         .md-mediaquery({
-            background: fuchsia;
             grid-area: left;
             transform: none;
         });
@@ -227,11 +245,9 @@
     }
 
     .rightPanel {
-        background: lime;
         transform: translateX(calc(100% - 30px));
         
         .md-mediaquery({
-            background: yellowgreen;
             grid-area: right;
             transform: none;
         });

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
@@ -20,6 +20,12 @@
 
 :root {
     --uv-animation: 1;
+
+    --uv-grid-left-width-open: 271px;
+    --uv-grid-right-width-open: 271px;
+
+    --uv-grid-left-width: 30px;
+    --uv-grid-right-width: 30px;
 }
 
 .hidden {
@@ -106,11 +112,7 @@
     .mainPanel {
 
         // TODO: set these at runtime in html element style attr by getting from config?
-        --uv-grid-left-width-open: 271px;
-        --uv-grid-right-width-open: 271px;
-
-        --uv-grid-left-width: 30px;
-        --uv-grid-right-width: 30px;
+        
 
         background: red;
         margin: 0;


### PR DESCRIPTION
Updates CSS and some small JS bits to allow the side panels to appear on mobile.

Currently only tested on OSD extension, but should work the same for all types.

Please excuse the garish colours - they're useful for checking which media queries are running and the stacking of the z-indexes :)

Summary of changes:

- CSS to hide the left and right panels (L & R from now on)  has been removed, building on James' changes. 
- As the panels are now 'visible' all the time, they're pulled off the viewport with a transform property. Aria props set by JS should still apply correctly. 
- The main panel has overflow hidden to allow this method of hiding. For now they still appear on the page just so they're clickable for testing, although in future there'll be header buttons to achieve this.
- At mobile sizes the L & R are absolutely positioned so that they'll 'float' over the top of the Main panel
- At medium and up the main panel has a grid layout with three columns so there's no need for JS to calculate and set widths for things
- CSS custom properties are used for the grid areas widths and to toggle animations. These will eventually need to be set as an inline style on the `<html>` element, which will allow config from JS to be passed to the CSS, but for now they're all in `styles.less` in the `:root` selector to simulate this.
- Animations are handled with CSS transitions. The `--uv-animation` property acts as a boolean toggle for this and can be set to 0 to disable animations without the need for more complex selectors.