### PR TITLE
Add console.error to give more information when loading config, extension, or manifest fails.

### DIFF
--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -406,6 +406,7 @@ export default class IIIFContentHandler
     } catch (e) {
       this.hideSpinner();
       alert("Unable to load manifest");
+      console.error(e);
     }
   }
 


### PR DESCRIPTION
"Unable to load manifest" hides a lot of information from many errors. I - I want that information. Can... Is it alright if I have it? Please?