### PR TITLE
Standardize window size for consistent test results.

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   launch: {
     headless: process.env.CI === 'true',
+    args: [`--window-size=1920,1080`],
+    defaultViewport: {
+      width: 1920,
+      height: 1080
+    }
   },
   server: {
     command: 'npm run e2eserve',


### PR DESCRIPTION
The default jest configuration did not specify a window size, which makes it hard to determine whether the viewer will start in mobile or desktop mode. This PR sets a desktop window size for default testing, since desktop is the current assumption of existing tests. We should be able to override this on a test-by-test basis if we want to develop mobile-specific tests in future.