### PR TITLE
Downgrade to OpenSeadragon 4.0.0 to fix aspect ratio issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "manifesto.js": "^4.2.21",
         "mediaelement": "4.2.15",
         "mediaelement-plugins": "2.5.1",
-        "openseadragon": "4.1.1",
+        "openseadragon": "4.0.0",
         "pdfjs-dist": "3.11.174",
         "pdfobject": "2.3.0",
         "react": "^19.0.0",
@@ -9963,9 +9963,9 @@
       }
     },
     "node_modules/openseadragon": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-4.1.1.tgz",
-      "integrity": "sha512-owU9gsasAcobLN+LM8lN58Xc2VDSDotY9mkrwS/NB6g9KX/PcusV4RZvhHng2RF/Q0pMziwldf62glwXoGnuzg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/openseadragon/-/openseadragon-4.0.0.tgz",
+      "integrity": "sha512-HsjSgqiiPwLkW5576GxDJ7Rax96iLUET8fnTsJvu7uYYkd+qzen3bflxHyph0OVVgZBKP9SpGH1nPdU4Mz0Z2A==",
       "license": "BSD-3-Clause",
       "funding": {
         "url": "https://opencollective.com/openseadragon"

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "manifesto.js": "^4.2.21",
     "mediaelement": "4.2.15",
     "mediaelement-plugins": "2.5.1",
-    "openseadragon": "4.1.1",
+    "openseadragon": "4.0.0",
     "pdfjs-dist": "3.11.174",
     "pdfobject": "2.3.0",
     "react": "^19.0.0",


### PR DESCRIPTION
It appears that OpenSeadragon 4.1 introduced some bugs that cause manifest rendering problems -- the most severe example being #1315, but with lesser impacts on some other manifests.

This PR downgrades to OSD 4.0.0 until an upstream fix can be found.