### PR TITLE
Share Menu: show URL input on mobile.

### DIFF
--- a/src/content-handlers/iiif/modules/uv-dialogues-module/ShareDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/ShareDialogue.ts
@@ -318,12 +318,6 @@ export class ShareDialogue<
     if (shareUrl) {
       this.$urlInput.val(shareUrl);
     }
-
-    if (this.extension.isMobile()) {
-      this.$urlInput.hide();
-    } else {
-      this.$urlInput.show();
-    }
   }
 
   getSelectedSize(): JQuery {


### PR DESCRIPTION
On [any platform that the UV considers to be mobile](https://github.com/UniversalViewer/universalviewer/blob/dev/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts#L1120-L1132), the UV will hide just the input box for the share menu. 

![share-broken](https://github.com/user-attachments/assets/5baaa214-14a9-4875-84fd-4d47cc91b7f6)

This fixes that!