### PR TITLE
Change active tab to @link-color for contrast.

### DIFF
--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/css/styles.less
@@ -117,7 +117,7 @@
         padding: 0 @padding-medium-horizontal 0 0;
 
         .iiif-tree-component ul li a.selected {
-          color: @brand-primary !important;
+          color: @link-color !important;
         }
       }
 

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/css/styles.less
@@ -35,7 +35,7 @@
         &.on {
           border: 1px solid @panel-border-color;
           border-bottom: 1px solid @panel-dark-bg;
-          color: @brand-secondary;
+          color: @link-color;
           margin-bottom: -1px;
           height: 25px;
           line-height: 25px;

--- a/src/content-handlers/iiif/modules/uv-ebookleftpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-ebookleftpanel-module/css/styles.less
@@ -19,7 +19,7 @@
           padding: @padding-medium;
 
           uv-ebook-toc {
-            --toc-link-selected-color: @brand-primary;
+            --toc-link-selected-color: @link-color;
             --toc-link-padding: 0.2rem;
             --toc-margin: 0;
             --toc-padding: 0;

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/overlays.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/overlays.less
@@ -12,6 +12,10 @@
     .overlay {
         position: absolute;
 
+        a {
+            color: @brand-primary; // for links on white background
+        }
+
         .top {
             width: 100%;
             overflow: auto;


### PR DESCRIPTION
This fixes the contrast issue by bringing tags to AA contrast like the links. If we want AAA contrast, here are some options:

- [Tailwind CSS](https://tailwindcss.com/docs/colors) - cyan 500 is the closest color in this palette. We can move to cyan-300 for text and cyan-700 for buttons.
- [Harmony](https://www.figma.com/community/file/1287828769207775946/harmony-accessible-ui-color-palette) - cyan-300 and cyan-700 for something less vibrant.
- We can switch hues to the purple or fuchsia that we see on the UV website.
