### PR TITLE
Only One Dialogue Overlay at a Time

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Dialogue.ts
@@ -137,6 +137,8 @@ export class Dialogue<
   }
 
   open(triggerButton?: HTMLElement): void {
+    this.extensionHost.publish(IIIFEvents.CLOSE_ACTIVE_DIALOGUE);
+
     this.$element.attr("aria-hidden", "false");
     this.$element.show();
 


### PR DESCRIPTION
Fix share and terms conflict by only opening one dialogue at a time.

TODO
- [ ] Close https://github.com/UniversalViewer/universalviewer/issues/1358 when merging