### PR TITLE
Add volume control to audio files on mobile devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "universalviewer",
-  "version": "4.2.0-rc1",
+  "version": "4.2.0-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "universalviewer",
-      "version": "4.2.0-rc1",
+      "version": "4.2.0-rc2",
       "license": "MIT",
       "dependencies": {
         "@edsilv/http-status-codes": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universalviewer",
-  "version": "4.2.0-rc1",
+  "version": "4.2.0-rc2",
   "description": "The Universal Viewer is a community-developed open source project on a mission to help you share your 📚📜📰📽️📻🗿 with the 🌎",
   "engines": {
     "node": ">=18",

--- a/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
@@ -324,6 +324,7 @@ export class MediaElementCenterPanel extends CenterPanel<
         ],
         stretching: "responsive",
         defaultAudioHeight: "auto",
+        hideVolumeOnTouchDevices: false,
         showPosterWhenPaused: true,
         showPosterWhenEnded: true,
         success: function (mediaElement: any, originalNode: any) {


### PR DESCRIPTION
Fixes #1364 - adds config so volume controls are still visible  for audio files on mobile devices. 
Works on iPhone with Safari, needs to be tested with other devices/browsers