### PR TITLE
Make osd controls visible from md+

### DIFF
--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
@@ -109,7 +109,7 @@
                 .zoomIn{
                     display: none !important;
 
-                    .xl-mediaquery({
+                    .md-mediaquery({
                         display: inline-block !important;
                         cursor: pointer !important;
                         background-image: data-uri('../img/zoom_in.png') !important;
@@ -128,7 +128,7 @@
                 .zoomOut{
                     display: none !important;
 
-                    .xl-mediaquery({
+                    .md-mediaquery({
                         display: inline-block !important;
                         cursor: pointer !important;
                         background-image: data-uri('../img/zoom_out.png') !important;
@@ -147,7 +147,7 @@
                 .goHome{
                     display: none !important;
 
-                    .xl-mediaquery({
+                    .md-mediaquery({
                         display: inline-block !important;
                         cursor: pointer !important;
                         background-image: data-uri('../img/home.png') !important;
@@ -170,7 +170,7 @@
                 .rotate{
                     display: none !important;
 
-                    .xl-mediaquery({
+                    .md-mediaquery({
                         display: inline-block !important;
                         cursor: pointer !important;
                         background-image: data-uri('../img/rotate_right.png') !important;
@@ -189,7 +189,7 @@
                 .adjustImage {
                     display: none !important;
 
-                    .xl-mediaquery({
+                    .md-mediaquery({
                         display: inline-block !important;
                         cursor: pointer !important;
                         background-image: data-uri('../img/adjust.png') !important;


### PR DESCRIPTION
Closes #1369 

Adjusts the media queries for the OSD controls so they appear on mid-sized devices (tablets and small laptops).

Oddly the fading behaviour in OSD doesn't seem to work when below 1024px, but I don't see that as a problem because at that size it's likely a touch device, so mouse events wouldn't work anyway.