### PR TITLE
Issue1402

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "universalviewer",
-  "version": "4.2.0-rc1",
+  "version": "4.2.0-rc2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "universalviewer",
-      "version": "4.2.0-rc1",
+      "version": "4.2.0-rc2",
       "license": "MIT",
       "dependencies": {
         "@edsilv/http-status-codes": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universalviewer",
-  "version": "4.2.0-rc1",
+  "version": "4.2.0-rc2",
   "description": "The Universal Viewer is a community-developed open source project on a mission to help you share your 📚📜📰📽️📻🗿 with the 🌎",
   "engines": {
     "node": ">=18",

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -123,6 +123,10 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
       }
     });
 
+    this.extensionHost.subscribe(IIIFEvents.TOGGLE_EXPAND_LEFT_PANEL, () => {
+      this.openThumbsView();
+    });
+
     // this.extensionHost.subscribe(
     //   OpenSeadragonExtensionEvents.PAGING_TOGGLED,
     //   (_paged: boolean) => {

--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -305,6 +305,8 @@ export class PagingHeaderPanel extends HeaderPanel<
 
     this.$galleryButton.onPressed(() => {
       this.extensionHost.publish(IIIFEvents.TOGGLE_EXPAND_LEFT_PANEL);
+      this.extensionHost.publish(IIIFEvents.OPEN_THUMBS_VIEW);
+      console.log('pressed')
     });
 
     this.setNavigationTitles();

--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -305,8 +305,6 @@ export class PagingHeaderPanel extends HeaderPanel<
 
     this.$galleryButton.onPressed(() => {
       this.extensionHost.publish(IIIFEvents.TOGGLE_EXPAND_LEFT_PANEL);
-      this.extensionHost.publish(IIIFEvents.OPEN_THUMBS_VIEW);
-      console.log('pressed')
     });
 
     this.setNavigationTitles();


### PR DESCRIPTION
This should fix https://github.com/UniversalViewer/universalviewer/issues/1402

When viewing IIIF content, there is a 1ms delay to the 'main' div in the left panel resizing in ContentLeftPanel.ts. For PDFs and media, the thumbsView is rendered in ResourcesLeftPanel.ts, so I *think* the problem was that the thumbnail div wasn't being resized in the same way/at the same time, so it was resizing before the panel expansion animation had finished. I've added the same delay (1ms) and set the width to 100% after that.

I haven't tested this very thoroughly, please give it a hammering and see what happens!