### PR TITLE
Update to iiif-gallery-component v1.1.23.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@google/model-viewer": "^4.0.0",
         "@iiif/base-component": "2.0.1",
         "@iiif/iiif-av-component": "1.2.4",
-        "@iiif/iiif-gallery-component": "^1.1.22",
+        "@iiif/iiif-gallery-component": "^1.1.23",
         "@iiif/iiif-metadata-component": "^1.2.1",
         "@iiif/iiif-tree-component": "^2.0.7",
         "@iiif/manifold": "^2.1.1",
@@ -1232,9 +1232,9 @@
       }
     },
     "node_modules/@iiif/iiif-gallery-component": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/@iiif/iiif-gallery-component/-/iiif-gallery-component-1.1.22.tgz",
-      "integrity": "sha512-d+iUi8HU5tMkVszbTqCnvA8H/a5rxM8PKVC8gNorMHyWdmEjaWSW2aNhSUQgItxKkxGEPYxXV1yisbsor5QL4A==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@iiif/iiif-gallery-component/-/iiif-gallery-component-1.1.23.tgz",
+      "integrity": "sha512-r6eUdBlCPhlqWp9fNiTkS0GeYFzFk0yXlEb4z1vRgGYdjRNUyPhe4doQvXgxQt7oShPLdpjfl92etydBwA6pfQ==",
       "license": "MIT",
       "dependencies": {
         "@edsilv/jquery-plugins": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@google/model-viewer": "^4.0.0",
     "@iiif/base-component": "2.0.1",
     "@iiif/iiif-av-component": "1.2.4",
-    "@iiif/iiif-gallery-component": "^1.1.22",
+    "@iiif/iiif-gallery-component": "^1.1.23",
     "@iiif/iiif-metadata-component": "^1.2.1",
     "@iiif/iiif-tree-component": "^2.0.7",
     "@iiif/manifold": "^2.1.1",


### PR DESCRIPTION
This update should eliminate content security policy warnings related to the gallery component, thanks to @anthonyhashemi's work on https://github.com/IIIF-Commons/iiif-gallery-component/pull/31.