### PR TITLE
Fix thumbnail panel search result display (resolves #1409)

### DIFF
--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useRef } from "react";
-import { Thumb } from "manifesto.js";
 import { ViewingDirection, ViewingHint } from "@iiif/vocabulary";
-import { useInView } from "react-intersection-observer";
 import cx from "classnames";
+import { Thumb } from "manifesto.js";
+import React, { useEffect, useRef } from "react";
+import { useInView } from "react-intersection-observer";
 
 const ThumbImage = ({
   first,
@@ -63,7 +63,7 @@ const ThumbImage = ({
       </div>
       <div className="info">
         <span className="label" title={thumb.label}>
-          {thumb.label}&nbsp;
+          {thumb.label}
         </span>
         {thumb.data.searchResults && (
           <span className="searchResults">{thumb.data.searchResults}</span>
@@ -136,7 +136,11 @@ const Thumbnails = ({
       })}
     >
       {thumbs.map((thumb, index) => (
-        <span key={`thumb-${index}`} id={`thumb-${index}`}>
+        <span
+          key={`thumb-${index}`}
+          id={`thumb-${index}`}
+          className="thumb-container"
+        >
           <ThumbImage
             first={index === firstNonPagedIndex}
             onClick={onClick}

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/thumbs-view.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/thumbs-view.less
@@ -96,14 +96,16 @@
 
             .thumbsView .thumbs .thumb .info .searchResults {
                 float: right;
-                width: 35px;
                 overflow-x: hidden;
                 text-overflow: ellipsis;
                 padding-left: 14px;
-                /* background-image: data-uri("../img/search_result.png"); */
+
+                /* styles copied from gallery component css */
+                color: #14a4c3;
+                background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAMAAACecocUAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyhpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMTMyIDc5LjE1OTI4NCwgMjAxNi8wNC8xOS0xMzoxMzo0MCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIDIwMTUuNSAoV2luZG93cykiIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QjIyODM1RTJCMEI5MTFFNkI5M0NGM0Q4NzkzMjRGNkQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QjIyODM1RTNCMEI5MTFFNkI5M0NGM0Q4NzkzMjRGNkQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpCMjI4MzVFMEIwQjkxMUU2QjkzQ0YzRDg3OTMyNEY2RCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpCMjI4MzVFMUIwQjkxMUU2QjkzQ0YzRDg3OTMyNEY2RCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pmw6yDsAAAAtUExURRxicx5PXBp6kB82PBpyhxtqfReQqxaXsxiJoh1ZaBWduxmCmR9FTxSkwyEfH7Q9FxwAAAAPdFJOU///////////////////ANTcmKEAAABNSURBVHjaRM0LDsBABARQ+2mXZdz/uIs27SSShwTyPxQ1udvjsRGh8o3L28ZIg2MkmGUNN/TyjrVC0gTwAqxuSkizofePYX12Mz8CDABtXwWf4T3nAgAAAABJRU5ErkJggg==");
                 background-repeat: no-repeat;
                 background-position-x: 0px;
-                background-position-y: 3px;
+                background-position-y: 4px;
             }
 
             .thumbsView .thumbs .thumb.placeholder .wrap {
@@ -131,6 +133,7 @@
                 width: 105px;
                 float: left;
                 margin: 0 0 0 7px;
+                padding-top: 2px;
             }
 
             .thumbsView .thumbs .thumb.oneCol .info .searchResults {
@@ -139,17 +142,30 @@
                 margin: 7px 0 0 0;
             }
 
-            .thumbsView .thumbs .thumb.twoCol {
-                margin: 0 7px 7px 0;
-            }
-
             .thumbsView .thumbs .thumb.twoCol .label {
-                width: 98px;
+                max-width: 98px !important;   
             }
 
             .thumbsView .thumbs .thumb.twoCol .wrap {
                 width: 98px;
                 max-height: 182px;
+                margin-bottom: -2px;
+            }
+
+            .thumbsView .thumbs .thumb.twoCol.selected .wrap {
+                margin-bottom: 0;
+            }
+
+            .thumbsView .thumbs .thumb.twoCol .info {
+                padding: 0 0 0 4px;
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: space-between;
+                width: 94px;
+            }
+
+            .thumbsView .thumbs .thumb.twoCol .info .searchResults {
+                float: none;
             }
 
             .thumbsView .thumbs .separator {
@@ -158,201 +174,39 @@
                 border: none;
             }
 
-            .thumbsView .thumbs.left-to-right.paged .thumb.first {
-                float: right;
+            .thumbsView .thumbs.paged {
+                display: grid;
+                grid-template-columns: repeat(2, 98px);
+                gap: 14px;
             }
 
-            .thumbsView .thumbs.left-to-right .thumb {
-                float: left;
+            .thumbsView .thumbs.paged .thumb-container:nth-child(1) {
+                grid-column: 2;
+            }
+            
+            .thumbsView .thumbs.paged .thumb-container:nth-child(2n):not(:first-child) {
+                grid-column: 1;
             }
 
-            .thumbsView .thumbs.right-to-left .thumb {
-                float: right;
+            .thumbsView .thumbs.paged .thumb-container:nth-child(2n+1):not(:first-child) {
+                grid-column: 2;
             }
 
-            // .thumbsView {
+            .thumbsView .thumbs.paged.right-to-left {
+                grid-auto-flow: dense;
+            }
 
-            //     overflow: auto;
-            //     height: 100%;
+            .thumbsView .thumbs.paged.right-to-left .thumb-container:nth-child(1) {
+                grid-column: 1 / span 2
+            }
 
-            //     .thumbs {
-            //         overflow: hidden;
-            //         width: 210px;
-            //         position: relative;
+            .thumbsView .thumbs.paged.right-to-left .thumb-container:nth-child(2n):not(:first-child) {
+                grid-column: 2;
+            }
 
-            //         .thumb {
-            //             cursor: pointer;
-
-            //             .wrap {
-            //                 border: 2px solid @panel-border-color;
-            //                 padding: 2px;
-            //                 overflow: hidden;
-            //                 text-align: center;
-            //                 background: @body-bg;
-
-            //                 &.loading {
-            //                     .loading(@loader-black-bg);
-            //                 }
-
-            //                 &.loadingFailed {
-            //                     background-image: data-uri('../img/error.png');
-            //                     background-repeat: no-repeat;
-            //                     background-position-x: 50%;
-            //                     background-position-y: 50%;
-            //                 }
-
-            //                 &.audio {
-            //                     background-image: data-uri('../img/audio.png');
-            //                 }
-
-            //                 &.video {
-            //                     background-image: data-uri('../img/video.png');
-            //                 }
-
-            //                 &.hidden {
-            //                     background-image: data-uri('../img/hidden_thumb.png');
-            //                     background-repeat: no-repeat;
-            //                     background-position-x: 50%;
-            //                     background-position-y: 50%;
-            //                 }
-
-            //                 img {
-            //                     display: block;
-            //                     max-width: 100%;
-            //                     max-height: 100%;
-            //                     //margin: 0 auto;
-            //                 }
-            //             }
-
-            //             &.selected {
-
-            //                 .wrap {
-            //                     border: 2px solid #fff;
-            //                 }
-            //             }
-
-            //             &.searchpreview {
-
-            //                 .wrap {
-            //                     border: 2px solid @link-color;
-            //                 }
-            //             }
-
-            //             .info {
-
-            //                 overflow: hidden;
-
-            //                 span {
-            //                     font-size: @font-size-small;
-            //                     color: #fff;
-            //                     display: block;
-            //                     padding: 2px 0 0 0;
-            //                 }
-
-            //                 .index {
-            //                     float: left;
-            //                 }
-
-            //                 .label {
-            //                     float: left;
-            //                     overflow-x: hidden;
-            //                     text-overflow: ellipsis;
-            //                     white-space: nowrap;
-            //                 }
-
-            //                 .searchResults {
-            //                     float: right;
-            //                     width: 35px;
-            //                     overflow-x: hidden;
-            //                     text-overflow: ellipsis;
-            //                     color: @brand-primary;
-            //                     padding-left: 14px;
-            //                     background-image: data-uri('../img/search_result.png');
-            //                     background-repeat: no-repeat;
-            //                     background-position-x: 0px;
-            //                     background-position-y: 3px;
-            //                 }
-            //             }
-
-            //             &.placeholder {
-            //                 .wrap {
-            //                     background-image: data-uri('../img/unavailable.png');
-            //                     background-repeat: no-repeat;
-            //                     background-position-x: 50%;
-            //                     background-position-y: 50%;
-            //                 }
-            //             }
-
-            //             &.oneCol {
-
-            //                 margin: 0 0 7px 0;
-
-            //                 .label {
-            //                     width: 178px;
-            //                 }
-
-            //                 .wrap {
-            //                     float: left;
-            //                     width: 90px;
-            //                     max-height: 90px;
-            //                     //width: 208px; // full width
-            //                     //max-height: 373px; // full height
-            //                 }
-
-            //                 .info {
-            //                     width: 113px;
-            //                     float: left;
-            //                     margin: 0 0 0 7px;
-
-            //                     .searchResults {
-            //                         clear: left;
-            //                         float: left;
-            //                         margin: 7px 0 0 0;
-            //                     }
-            //                 }
-            //             }
-
-            //             &.twoCol {
-            //                 margin: 0 7px 7px 0;
-            //                 .label {
-            //                     width: 63px;
-            //                 }
-            //                 .wrap {
-            //                     width: 98px;
-            //                     max-height: 182px;
-            //                 }
-            //             }
-            //         }
-
-            //         .separator {
-            //             height: 1px;
-            //             clear: both;
-            //             border: none;
-            //         }
-
-            //         &.left-to-right {
-            //             &.paged {
-            //                 .thumb {
-            //                     &.first {
-            //                         float: right;
-            //                     }
-            //                 }
-            //             }
-            //             .thumb {
-            //                 float: left;
-            //             }
-            //         }
-
-            //         &.right-to-left {
-            //             .thumb {
-            //                 &.first {
-            //                     //float: left;
-            //                 }
-            //                 float: right;
-            //             }
-            //         }
-            //     }
-            // }
+            .thumbsView .thumbs.paged.right-to-left .thumb-container:nth-child(2n+1):not(:first-child) {
+                grid-column: 1;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1409 

Copies colour + image from gallery view component

Removes fixed width from the label which was breaking layout. Selector left commented out in case needed in future (see below)

I would recommend a CSS update of the thumbs view to use grid rather than floats at some point, but I've left it as-is for now.