### PR TITLE
Layout Fix: hide empty left and right panels

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/styles.less
@@ -126,6 +126,16 @@
             transition-timing-function: linear;
             transition-duration: calc(var(--uv-animation) * var(--uv-animation-duration));
         });
+
+        /* hide empty panels */
+
+        &:has(.leftPanel:empty) {
+            --uv-grid-left-width: auto;
+        }
+
+        &:has(.rightPanel:empty) {
+            --uv-grid-right-width: auto;
+        }
     }
 
     .mainPanel.leftPanelOpen {


### PR DESCRIPTION
The grid is set to 30px for closed panels. When a panel isn't active (audio or single page pdfs) this results in a 30px wide gray bar.

This PR sets the CSS variables to "auto" when a panel is empty, collapsing that space and giving it to the center view.


[Florence Nightingale (audio)](http://localhost:8080/#?xywh=&iiifManifestId=https%3A%2F%2Fwellcomelibrary.org%2Fiiif%2Fb17307922%2Fmanifest) is a good test for this since it has no left panel. Compare [https://universalviewer.dev](http://localhost:8080/#?xywh=&iiifManifestId=https%3A%2F%2Fwellcomelibrary.org%2Fiiif%2Fb17307922%2Fmanifest) to preview below!