### PR TITLE
Fix adjust image dialogue background

### DIFF
--- a/src/content-handlers/iiif/modules/uv-dialogues-module/AdjustImageDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/AdjustImageDialogue.ts
@@ -150,8 +150,9 @@ export class AdjustImageDialogue extends Dialogue<
         this.rememberSettings = settings.rememberSettings;
       }
     }
-    this.shell.$overlays.css("background", "none");
+
     super.open();
+    this.shell.$overlays.css("background", "none");
   }
 
   close(): void {
@@ -173,6 +174,7 @@ export class AdjustImageDialogue extends Dialogue<
       this.extension.updateSettings({ brightnessPercent: 100 });
       this.extension.updateSettings({ saturationPercent: 100 });
     }
+
     this.shell.$overlays.css("background", "");
     super.close();
 
@@ -184,5 +186,7 @@ export class AdjustImageDialogue extends Dialogue<
 
   resize(): void {
     super.resize();
+
+    this.$element.css({ top: 16, left: 16 });
   }
 }

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/css/styles.less
@@ -349,6 +349,7 @@
         &.adjustImage {
             width: 330px;
             height: 250px;
+            border: 1px solid black;
 
             label {
                 margin-top: 10px;


### PR DESCRIPTION
**Now based on release-4.2.0.**

Having the half-shaded and textured background behind the adjust image overlay makes those adjustments a guessing game. Moving the style adjustment down fixes the proper order of operations to remove the background.

Also:

- add a black border to increase the visual contrast of the overlay.
- move the overlay to the top left to hopefully hide less of the image.