### PR TITLE
Eslint let const

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -23,7 +23,7 @@ module.exports = defineConfig([
     },
     rules: {
       semi: "error",
-      "prefer-const": "off",
+      "prefer-const": "error",
     },
     settings: {
       react: {

--- a/src/BaseContentHandler.ts
+++ b/src/BaseContentHandler.ts
@@ -68,7 +68,7 @@ export default class BaseContentHandler<IUVData>
   }
 
   public async configure(config: any): Promise<any> {
-    let promises: Promise<any>[] = [] as any;
+    const promises: Promise<any>[] = [] as any;
 
     this.fire(Events.CONFIGURE, {
       config,

--- a/src/Init.ts
+++ b/src/Init.ts
@@ -23,18 +23,20 @@ export const init = (el: string | HTMLDivElement, data) => {
   });
 
   const resize = () => {
-    if (uv) {
-      if (isFullScreen && !overrideFullScreen) {
-        // is full screen and not overridden.
-        parent.style.width = window.innerWidth + "px";
-        parent.style.height = window.innerHeight + "px";
-      } else {
-        // either we're not full screen or scaling to the window size is overridden
-        parent.style.width = container.offsetWidth + "px";
-        parent.style.height = container.offsetHeight + "px";
-      }
-      uv.resize();
+    if (!uv) {
+      return;
     }
+
+    if (isFullScreen && !overrideFullScreen) {
+      // is full screen and not overridden.
+      parent.style.width = window.innerWidth + "px";
+      parent.style.height = window.innerHeight + "px";
+    } else {
+      // either we're not full screen or scaling to the window size is overridden
+      parent.style.width = container.offsetWidth + "px";
+      parent.style.height = container.offsetHeight + "px";
+    }
+    uv.resize();
   };
 
   window.addEventListener("resize", function () {

--- a/src/Init.ts
+++ b/src/Init.ts
@@ -2,7 +2,6 @@ import { Events } from "./Events";
 import { UniversalViewer } from "./UniversalViewer";
 
 export const init = (el: string | HTMLDivElement, data) => {
-  let uv;
   let isFullScreen = false;
   let overrideFullScreen = false;
   const container = typeof el === "string" ? document.getElementById(el) : el;
@@ -17,6 +16,11 @@ export const init = (el: string | HTMLDivElement, data) => {
   // extra div is needed for safari full screen
   const uvDiv = document.createElement("div");
   parent.appendChild(uvDiv);
+
+  const uv = new UniversalViewer({
+    target: uvDiv,
+    data: data,
+  });
 
   const resize = () => {
     if (uv) {
@@ -41,11 +45,6 @@ export const init = (el: string | HTMLDivElement, data) => {
     setTimeout(function () {
       resize();
     }, 100);
-  });
-
-  uv = new UniversalViewer({
-    target: uvDiv,
-    data: data,
   });
 
   // todo: can we remove the following two event listeners

--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -276,7 +276,7 @@ export default class IIIFContentHandler
       data.locales = [];
       data.locales.push(defaultLocale);
     }
-    let config = await extension.loadConfig(
+    const config = await extension.loadConfig(
       data.locales[0].name,
       extension?.type.name
     );

--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -36,71 +36,70 @@ const Extension: IExtensionRegistry = {
     name: "uv-av-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-av-extension/Extension"
-      ),
+      "./extensions/uv-av-extension/Extension"
+    ),
   },
   ALEPH: {
     name: "uv-aleph-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-aleph-extension/Extension"
-      ),
+      "./extensions/uv-aleph-extension/Extension"
+    ),
   },
   DEFAULT: {
     name: "uv-default-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-default-extension/Extension"
-      ),
+      "./extensions/uv-default-extension/Extension"
+    ),
   },
   EBOOK: {
     name: "uv-ebook-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-ebook-extension/Extension"
-      ),
+      "./extensions/uv-ebook-extension/Extension"
+    ),
   },
   MEDIAELEMENT: {
     name: "uv-mediaelement-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-mediaelement-extension/Extension"
-      ),
+      "./extensions/uv-mediaelement-extension/Extension"
+    ),
   },
   MODELVIEWER: {
     name: "uv-model-viewer-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-model-viewer-extension/Extension"
-      ),
+      "./extensions/uv-model-viewer-extension/Extension"
+    ),
   },
   OSD: {
     name: "uv-openseadragon-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-openseadragon-extension/Extension"
-      ),
+      "./extensions/uv-openseadragon-extension/Extension"
+    ),
   },
   PDF: {
     name: "uv-pdf-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-pdf-extension/Extension"
-      ),
+      "./extensions/uv-pdf-extension/Extension"
+    ),
   },
   SLIDEATLAS: {
     name: "uv-openseadragon-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-        "./extensions/uv-openseadragon-extension/Extension"
-      ),
+      "./extensions/uv-openseadragon-extension/Extension"
+    ),
   },
 };
 
 export default class IIIFContentHandler
   extends BaseContentHandler<IIIFData>
-  implements IIIFExtensionHost, IContentHandler<IIIFData>
-{
+  implements IIIFExtensionHost, IContentHandler<IIIFData> {
   private _extensionRegistry: IExtensionRegistry;
   private _pubsub: PubSub;
   public extension: IExtension | undefined;
@@ -323,9 +322,7 @@ export default class IIIFContentHandler
         window.trackingLabel = trackingLabel;
       }
 
-      let canvas: Canvas | undefined;
-
-      canvas = helper.getCurrentCanvas();
+      const canvas: Canvas | undefined = helper.getCurrentCanvas();
 
       if (!canvas) {
         that._error(`Canvas ${data.canvasIndex} not found.`);

--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -36,70 +36,71 @@ const Extension: IExtensionRegistry = {
     name: "uv-av-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-av-extension/Extension"
-    ),
+        "./extensions/uv-av-extension/Extension"
+      ),
   },
   ALEPH: {
     name: "uv-aleph-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-aleph-extension/Extension"
-    ),
+        "./extensions/uv-aleph-extension/Extension"
+      ),
   },
   DEFAULT: {
     name: "uv-default-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-default-extension/Extension"
-    ),
+        "./extensions/uv-default-extension/Extension"
+      ),
   },
   EBOOK: {
     name: "uv-ebook-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-ebook-extension/Extension"
-    ),
+        "./extensions/uv-ebook-extension/Extension"
+      ),
   },
   MEDIAELEMENT: {
     name: "uv-mediaelement-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-mediaelement-extension/Extension"
-    ),
+        "./extensions/uv-mediaelement-extension/Extension"
+      ),
   },
   MODELVIEWER: {
     name: "uv-model-viewer-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-model-viewer-extension/Extension"
-    ),
+        "./extensions/uv-model-viewer-extension/Extension"
+      ),
   },
   OSD: {
     name: "uv-openseadragon-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-openseadragon-extension/Extension"
-    ),
+        "./extensions/uv-openseadragon-extension/Extension"
+      ),
   },
   PDF: {
     name: "uv-pdf-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-pdf-extension/Extension"
-    ),
+        "./extensions/uv-pdf-extension/Extension"
+      ),
   },
   SLIDEATLAS: {
     name: "uv-openseadragon-extension",
     loader: () =>
       /* webpackMode: "lazy" */ import(
-      "./extensions/uv-openseadragon-extension/Extension"
-    ),
+        "./extensions/uv-openseadragon-extension/Extension"
+      ),
   },
 };
 
 export default class IIIFContentHandler
   extends BaseContentHandler<IIIFData>
-  implements IIIFExtensionHost, IContentHandler<IIIFData> {
+  implements IIIFExtensionHost, IContentHandler<IIIFData>
+{
   private _extensionRegistry: IExtensionRegistry;
   private _pubsub: PubSub;
   public extension: IExtension | undefined;

--- a/src/content-handlers/iiif/JQueryPlugins.ts
+++ b/src/content-handlers/iiif/JQueryPlugins.ts
@@ -270,7 +270,7 @@ export default function jqueryPlugins($) {
     return result;
   };
 
-  let on = $.fn.on;
+  const on = $.fn.on;
   let timer: any;
 
   $.fn.on = function () {

--- a/src/content-handlers/iiif/URLAdapter.ts
+++ b/src/content-handlers/iiif/URLAdapter.ts
@@ -45,7 +45,7 @@ export class URLAdapter extends UVAdapter {
     const locales = this.get<string>("locales", "");
     if (locales) {
       const names = locales.split(",");
-      for (let i in names) {
+      for (const i in names) {
         const parts = String(names[i]).split(":");
         formattedLocales[i] = { name: parts[0], label: parts[1] };
       }

--- a/src/content-handlers/iiif/extensions/uv-av-extension/DownloadDialogue.ts
+++ b/src/content-handlers/iiif/extensions/uv-av-extension/DownloadDialogue.ts
@@ -64,7 +64,7 @@ export class DownloadDialogue extends BaseDownloadDialogue {
 
       const id: string = $selectedOption.attr("id");
       const label: string = $selectedOption.attr("title");
-      let type: string = DownloadOption.UNKNOWN;
+      const type: string = DownloadOption.UNKNOWN;
 
       if (this.renderingUrls[<any>id]) {
         window.open(this.renderingUrls[<any>id]);

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
@@ -1111,20 +1111,20 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
 
     width = Math.min(width, resourceWidth);
     height = Math.min(height, resourceHeight);
-    let regionWidth: number = width;
-    let regionHeight: number = height;
+    const regionWidth: number = width;
+    const regionHeight: number = height;
 
     const maxDimensions: Size | null = canvas.getMaxDimensions();
 
     if (maxDimensions) {
       if (width > maxDimensions.width) {
-        let newWidth: number = maxDimensions.width;
+        const newWidth: number = maxDimensions.width;
         height = Math.round(newWidth * (height / width));
         width = newWidth;
       }
 
       if (height > maxDimensions.height) {
-        let newHeight: number = maxDimensions.height;
+        const newHeight: number = maxDimensions.height;
         width = Math.round((width / height) * newHeight);
         height = newHeight;
       }
@@ -1531,7 +1531,7 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
     let index: number;
 
     if (this.isPagingSettingEnabled()) {
-      let indices: number[] = this.getPagedIndices(canvasIndex);
+      const indices: number[] = this.getPagedIndices(canvasIndex);
 
       if (this.helper.isRightToLeft()) {
         index = indices[indices.length - 1] - 1;
@@ -1551,7 +1551,7 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
     // const canvas: Canvas | null = this.helper.getCanvasByIndex(canvasIndex);
 
     if (this.isPagingSettingEnabled()) {
-      let indices: number[] = this.getPagedIndices(canvasIndex);
+      const indices: number[] = this.getPagedIndices(canvasIndex);
 
       if (this.helper.isRightToLeft()) {
         index = indices[0] + 1;

--- a/src/content-handlers/iiif/modules/uv-alephcenterpanel-module/AlephCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-alephcenterpanel-module/AlephCenterPanel.ts
@@ -231,7 +231,7 @@ export class AlephCenterPanel extends CenterPanel<
 
   async openMedia(resources: IExternalResource[]) {
     this.extension.getExternalResources(resources).then(async () => {
-      let canvas: Canvas = this.extension.helper.getCurrentCanvas();
+      const canvas: Canvas = this.extension.helper.getCurrentCanvas();
 
       const annotations: Annotation[] = canvas.getContent();
 

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -495,13 +495,13 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
         const searchResult: AnnotationGroup = searchResults[i];
 
         // find the thumb with the same canvasIndex and add the searchResult
-        let thumb: Thumb = thumbs.filter(
+        const thumb: Thumb = thumbs.filter(
           (t) => t.index === searchResult.canvasIndex
         )[0];
 
         if (thumb) {
           // clone the data so searchResults isn't persisted on the canvas.
-          let data = Object.assign({}, thumb.data);
+          const data = Object.assign({}, thumb.data);
           data.searchResults = searchResult.rects.length;
           thumb.data = data;
         }

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/AdjustImageDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/AdjustImageDialogue.ts
@@ -114,7 +114,7 @@ export class AdjustImageDialogue extends Dialogue<
       this.$contrastInput.val(this.contrastPercent);
       this.$brightnessInput.val(this.brightnessPercent);
       this.$saturationInput.val(this.saturationPercent);
-      let canvas = <HTMLCanvasElement>(
+      const canvas = <HTMLCanvasElement>(
         (<OpenSeadragonExtension>this.extension).centerPanel.$canvas[0]
           .children[0]
       );
@@ -126,7 +126,7 @@ export class AdjustImageDialogue extends Dialogue<
   }
 
   filter(): void {
-    let canvas = <HTMLCanvasElement>(
+    const canvas = <HTMLCanvasElement>(
       (<OpenSeadragonExtension>this.extension).centerPanel.$canvas[0]
         .children[0]
     );
@@ -135,7 +135,7 @@ export class AdjustImageDialogue extends Dialogue<
 
   open(): void {
     // Check if we have saved setings
-    let settings = this.extension.getSettings();
+    const settings = this.extension.getSettings();
     if (settings.rememberSettings) {
       this.contrastPercent = Number(settings.contrastPercent);
       this.brightnessPercent = Number(settings.brightnessPercent);

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/AuthDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/AuthDialogue.ts
@@ -89,9 +89,9 @@ export class AuthDialogue extends Dialogue<
 
     super.open();
 
-    let header: string | null = this.service.getHeader();
-    let description: string | null = this.service.getDescription();
-    let confirmLabel: string | null = this.service.getConfirmLabel();
+    const header: string | null = this.service.getHeader();
+    const description: string | null = this.service.getDescription();
+    const confirmLabel: string | null = this.service.getConfirmLabel();
 
     if (header) {
       this.$title.text(sanitize(header));

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
@@ -287,7 +287,7 @@ export class DownloadDialogue extends Dialogue<
   }
 
   getFileExtension(fileUri: string): string | null {
-    let extension: string = <string>fileUri.split(".").pop();
+    const extension: string = <string>fileUri.split(".").pop();
 
     // if it's not a valid file extension
     if (extension.length > 5 || extension.indexOf("/") !== -1) {

--- a/src/content-handlers/iiif/modules/uv-ebookcenterpanel-module/EbookCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-ebookcenterpanel-module/EbookCenterPanel.ts
@@ -118,7 +118,7 @@ export class EbookCenterPanel extends CenterPanel<
 
   openMedia(resources: IExternalResource[]) {
     this.extension.getExternalResources(resources).then(() => {
-      let canvas: Canvas = this.extension.helper.getCurrentCanvas();
+      const canvas: Canvas = this.extension.helper.getCurrentCanvas();
 
       const annotations: Annotation[] = canvas.getContent();
 

--- a/src/content-handlers/iiif/modules/uv-filelinkcenterpanel-module/FileLinkCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-filelinkcenterpanel-module/FileLinkCenterPanel.ts
@@ -78,7 +78,7 @@ export class FileLinkCenterPanel extends CenterPanel<
         $fileName.text(id.substr(id.lastIndexOf("/") + 1));
       }
 
-      let label: string | null = LanguageMap.getValue(
+      const label: string | null = LanguageMap.getValue(
         annotationBody.getLabel()
       );
 
@@ -94,7 +94,7 @@ export class FileLinkCenterPanel extends CenterPanel<
         $thumb.hide();
       }
 
-      let description: string | null =
+      const description: string | null =
         annotationBody.getProperty("description");
 
       if (description) {

--- a/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/js/source-chooser-fixed.js
+++ b/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/js/source-chooser-fixed.js
@@ -162,14 +162,14 @@
               "keydown",
               function (e) {
                 function focusNext(dir = 1) {
-                  let radioEls = Array.from(
+                  const radioEls = Array.from(
                     player.sourcechooserButton.querySelectorAll(
                       'input[type="radio"]'
                     )
                   );
-                  let index = radioEls.indexOf(document.activeElement);
-                  let next = dir === 1 ? 1 : radioEls.length - 1;
-                  let nextIndex = (index + next) % radioEls.length;
+                  const index = radioEls.indexOf(document.activeElement);
+                  const next = dir === 1 ? 1 : radioEls.length - 1;
+                  const nextIndex = (index + next) % radioEls.length;
                   radioEls[nextIndex].focus();
                 }
 
@@ -216,7 +216,7 @@
                     case 9: // Tab
                       if (player.isSourcechooserSelectorOpen()) {
                         // Get focused element
-                        let checked = document.activeElement;
+                        const checked = document.activeElement;
                         // Focus next radio element
                         if (
                           checked.matches('input[type="radio"]') &&
@@ -243,7 +243,7 @@
                           document.activeElement
                         )
                       ) {
-                        let dir = keyCode === 37 || keyCode === 38 ? -1 : 1;
+                        const dir = keyCode === 37 || keyCode === 38 ? -1 : 1;
                         focusNext(dir);
                         stopPropagation = true;
                       }

--- a/src/content-handlers/iiif/modules/uv-modelviewercenterpanel-module/ModelViewerCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-modelviewercenterpanel-module/ModelViewerCenterPanel.ts
@@ -171,7 +171,7 @@ export class ModelViewerCenterPanel extends CenterPanel<
     await this.extension.getExternalResources(resources);
 
     let mediaUri: string | null = null;
-    let canvas: Canvas = this.extension.helper.getCurrentCanvas();
+    const canvas: Canvas = this.extension.helper.getCurrentCanvas();
     const formats: AnnotationBody[] | null =
       this.extension.getMediaFormats(canvas);
 

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -361,7 +361,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       ],
     });
 
-    let $oldZoomIn = this.$viewer.find('div[title="Zoom in"]');
+    const $oldZoomIn = this.$viewer.find('div[title="Zoom in"]');
     this.$zoomInButton = $("<button />").append($oldZoomIn.contents());
     this.$zoomInButton.insertAfter($oldZoomIn);
     $oldZoomIn.remove();
@@ -374,7 +374,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       this.zoomIn();
     });
 
-    let $oldZoomOut = this.$viewer.find('div[title="Zoom out"]');
+    const $oldZoomOut = this.$viewer.find('div[title="Zoom out"]');
     this.$zoomOutButton = $("<button />").append($oldZoomOut.contents());
     this.$zoomOutButton.insertAfter($oldZoomOut);
     $oldZoomIn.remove();
@@ -387,7 +387,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       this.zoomOut();
     });
 
-    let $oldGoHome = this.$viewer.find('div[title="Go home"]');
+    const $oldGoHome = this.$viewer.find('div[title="Go home"]');
     this.$goHomeButton = $("<button />").append($oldGoHome.contents());
     this.$goHomeButton.insertAfter($oldGoHome);
     $oldGoHome.remove();
@@ -400,7 +400,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       this.goHome();
     });
 
-    let $oldRotate = this.$viewer.find('div[title="Rotate right"]');
+    const $oldRotate = this.$viewer.find('div[title="Rotate right"]');
     this.$rotateButton = $("<button />").append($oldRotate.contents());
     this.$rotateButton.insertAfter($oldRotate);
     $oldRotate.remove();
@@ -458,14 +458,14 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     this.$canvas = $(this.viewer.canvas);
 
     // Check if we have saved settings for image adjustment
-    let settings = this.extension.getSettings();
+    const settings = this.extension.getSettings();
     if (
       this.extension.data.config?.options.saveUserSettings &&
       settings.rememberSettings
     ) {
-      let contrastPercent = settings.contrastPercent;
-      let brightnessPercent = settings.brightnessPercent;
-      let saturationPercent = settings.saturationPercent;
+      const contrastPercent = settings.contrastPercent;
+      const brightnessPercent = settings.brightnessPercent;
+      const saturationPercent = settings.saturationPercent;
       (<HTMLCanvasElement>this.$canvas[0].children[0]).style.filter =
         `contrast(${contrastPercent}%) brightness(${brightnessPercent}%) saturate(${saturationPercent}%)`;
     }
@@ -680,7 +680,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
   async getGirderTileSource(): Promise<any> {
     return new Promise<any>((resolve) => {
-      let canvas: Canvas = this.extension.helper.getCurrentCanvas();
+      const canvas: Canvas = this.extension.helper.getCurrentCanvas();
       const annotations: Annotation[] = canvas.getContent();
 
       if (annotations.length) {
@@ -924,7 +924,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
   }
 
   zoomToInitialAnnotation(): void {
-    let annotationRect: AnnotationRect | null = this.getInitialAnnotationRect();
+    const annotationRect: AnnotationRect | null = this.getInitialAnnotationRect();
 
     (this.extension as OpenSeadragonExtension).previousAnnotationRect = null;
     (this.extension as OpenSeadragonExtension).currentAnnotationRect = null;
@@ -1117,7 +1117,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
   }
 
   getAnnotationsForCurrentImages(): AnnotationGroup[] {
-    let annotationsForCurrentImages: AnnotationGroup[] = [];
+    const annotationsForCurrentImages: AnnotationGroup[] = [];
     const annotations: AnnotationGroup[] | null = (
       this.extension as OpenSeadragonExtension
     ).annotations;
@@ -1161,8 +1161,8 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       this.getAnnotationRectsForCurrentImages();
 
     for (let i = 0; i < annotationRects.length; i++) {
-      let rect: AnnotationRect = annotationRects[i];
-      let viewportBounds: any = this.viewer.viewport.getBounds();
+      const rect: AnnotationRect = annotationRects[i];
+      const viewportBounds: any = this.viewer.viewport.getBounds();
 
       rect.isVisible = Dimensions.hitRect(
         viewportBounds.x,
@@ -1379,16 +1379,16 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
   }
 
   getAnnotationOverlayRects(annotationGroup: AnnotationGroup): any[] {
-    let newRects: any[] = [];
+    const newRects: any[] = [];
 
     if (!this.extension.resources) {
       return newRects;
     }
 
-    let resource: any = this.extension.resources.filter(
+    const resource: any = this.extension.resources.filter(
       (x) => x.index === annotationGroup.canvasIndex
     )[0];
-    let index: number = this.extension.resources.indexOf(resource);
+    const index: number = this.extension.resources.indexOf(resource);
     let offsetX: number = 0;
 
     if (index > 0) {

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -924,7 +924,8 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
   }
 
   zoomToInitialAnnotation(): void {
-    const annotationRect: AnnotationRect | null = this.getInitialAnnotationRect();
+    const annotationRect: AnnotationRect | null =
+      this.getInitialAnnotationRect();
 
     (this.extension as OpenSeadragonExtension).previousAnnotationRect = null;
     (this.extension as OpenSeadragonExtension).currentAnnotationRect = null;

--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -310,7 +310,7 @@ export class PagingHeaderPanel extends HeaderPanel<
     this.setNavigationTitles();
     this.setTotal();
 
-    let viewingDirection: ViewingDirection =
+    const viewingDirection: ViewingDirection =
       this.extension.helper.getViewingDirection() ||
       ViewingDirection.LEFT_TO_RIGHT;
 

--- a/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -284,7 +284,7 @@ export class PDFCenterPanel extends CenterPanel<
     await this.extension.getExternalResources(resources);
 
     let mediaUri: string | null = null;
-    let canvas: Canvas = this.extension.helper.getCurrentCanvas();
+    const canvas: Canvas = this.extension.helper.getCurrentCanvas();
     const formats: AnnotationBody[] | null =
       this.extension.getMediaFormats(canvas);
     const pdfUri: string = canvas.id;

--- a/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfheaderpanel-module/PDFHeaderPanel.ts
@@ -191,7 +191,7 @@ export class PDFHeaderPanel extends HeaderPanel<
       return;
     }
 
-    let index: number = parseInt(this.$searchText.val(), 10);
+    const index: number = parseInt(this.$searchText.val(), 10);
 
     if (isNaN(index)) {
       this.extension.showMessage(

--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/FooterPanel.ts
@@ -404,14 +404,14 @@ export class FooterPanel extends BaseFooterPanel<
   getFirstSearchResultCanvasIndex(): number {
     const searchResults: AnnotationGroup[] | null = this.getSearchResults();
     if (!searchResults || !searchResults.length) return -1;
-    let firstSearchResultCanvasIndex: number = searchResults[0].canvasIndex;
+    const firstSearchResultCanvasIndex: number = searchResults[0].canvasIndex;
     return firstSearchResultCanvasIndex;
   }
 
   getLastSearchResultCanvasIndex(): number {
     const searchResults: AnnotationGroup[] | null = this.getSearchResults();
     if (!searchResults || !searchResults.length) return -1;
-    let lastSearchResultCanvasIndex: number =
+    const lastSearchResultCanvasIndex: number =
       searchResults[searchResults.length - 1].canvasIndex;
     return lastSearchResultCanvasIndex;
   }
@@ -650,8 +650,8 @@ export class FooterPanel extends BaseFooterPanel<
         );
       }
 
-      let instanceFoundText: string = that.content.instanceFound;
-      let instancesFoundText: string = that.content.instancesFound;
+      const instanceFoundText: string = that.content.instanceFound;
+      const instancesFoundText: string = that.content.instancesFound;
       let text: string = "";
 
       if (result.rects.length === 1) {
@@ -669,7 +669,7 @@ export class FooterPanel extends BaseFooterPanel<
 
     const pos: any = $placemarker.position();
 
-    let top: number = pos.top - that.$placemarkerDetails.height();
+    const top: number = pos.top - that.$placemarkerDetails.height();
     let left: number = pos.left;
 
     if (left < that.$placemarkerDetails.width() / 2) {

--- a/src/content-handlers/iiif/modules/uv-shared-module/Auth1.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Auth1.ts
@@ -68,7 +68,7 @@ export class Auth1 {
   }
 
   static getCookieServiceUrl(service: Service): string {
-    let cookieServiceUrl: string = service.id + "?origin=" + Auth1.getOrigin();
+    const cookieServiceUrl: string = service.id + "?origin=" + Auth1.getOrigin();
     return cookieServiceUrl;
   }
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/Auth1.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Auth1.ts
@@ -68,7 +68,8 @@ export class Auth1 {
   }
 
   static getCookieServiceUrl(service: Service): string {
-    const cookieServiceUrl: string = service.id + "?origin=" + Auth1.getOrigin();
+    const cookieServiceUrl: string =
+      service.id + "?origin=" + Auth1.getOrigin();
     return cookieServiceUrl;
   }
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -104,7 +104,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
 
   toggle(autoToggled?: boolean): void {
     const settings = this.extension.getSettings();
-    let isReducedAnimation = settings.reducedAnimation;
+    const isReducedAnimation = settings.reducedAnimation;
 
     const oldAnimationDuration =
       document.documentElement.style.getPropertyValue(
@@ -166,7 +166,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
 
   expandFull(): void {
     const settings = this.extension.getSettings();
-    let isReducedAnimation = settings.reducedAnimation;
+    const isReducedAnimation = settings.reducedAnimation;
 
     const oldAnimationDuration =
       document.documentElement.style.getPropertyValue(
@@ -210,7 +210,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
 
   collapseFull(): void {
     const settings = this.extension.getSettings();
-    let isReducedAnimation = settings.reducedAnimation;
+    const isReducedAnimation = settings.reducedAnimation;
 
     const oldAnimationDuration =
       document.documentElement.style.getPropertyValue(

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -482,14 +482,14 @@ export class BaseExtension<T extends BaseConfig> implements IExtension {
     config: Object,
     locale: String
   ): Promise<Object> {
-    let loader =
+    const loader =
       this.localeLoaders[locale as any] || this.localeLoaders["en-GB"];
-    let localeStrings = (await loader()) || {};
+    const localeStrings = (await loader()) || {};
     let conf = JSON.stringify(config);
 
-    for (let str in localeStrings) {
-      let replaceStr = str.replace("$", "");
-      let re = new RegExp(`\\$${replaceStr}\\b`, "g");
+    for (const str in localeStrings) {
+      const replaceStr = str.replace("$", "");
+      const re = new RegExp(`\\$${replaceStr}\\b`, "g");
       conf = conf.replace(re, localeStrings[str]);
     }
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/Panel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/Panel.ts
@@ -48,7 +48,7 @@ export class Panel {
     el.on("keydown", (e) => {
       // by passing treatAsButton  as true this will become false
       // and so an anchor won't be excluded from Space presses
-      let isAnchor = e.target.nodeName === "A" && !treatAsButton;
+      const isAnchor = e.target.nodeName === "A" && !treatAsButton;
 
       // 13 = Enter, 32 = Space
       if ((e.which === 32 && !isAnchor) || e.which === 13) {

--- a/src/content-handlers/iiif/modules/uv-shared-module/TestExternalResource.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/TestExternalResource.ts
@@ -378,7 +378,7 @@ export class ExternalResource implements IExternalResource {
 
         xhr.onload = () => {
           const data = JSON.parse(xhr.responseText);
-          let contentLocation: string = unescape(data.contentLocation);
+          const contentLocation: string = unescape(data.contentLocation);
 
           that.status = xhr.status;
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/ThumbsView.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/ThumbsView.ts
@@ -154,7 +154,7 @@ export class ThumbsView<T extends ExtendedLeftPanel> extends BaseView<T> {
     if (!this.thumbs) return;
 
     // get median height
-    let heights: number[] = [];
+    const heights: number[] = [];
 
     for (let i = 0; i < this.thumbs.length; i++) {
       const thumb: Thumb = this.thumbs[i];


### PR DESCRIPTION
Resolves #1429.

Updates the eslint config to error when `let` could/should be `const`

Runs that config over the src directory

Manually changes `canvas` and `uv` vars to be const because ESLint was unable to do it automatically.