### PR TITLE
Add back the ? in embed url

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -836,7 +836,7 @@ export class BaseExtension<T extends BaseConfig> implements IExtension {
     const title: string = this.helper.getLabel() ?? "";
 
     if ((hashParams?.size ?? 0) > 0) {
-      appUri += `#${hashParams.toString()}`;
+      appUri += `#?${hashParams.toString()}`;
     }
 
     const script: string = Strings.format(


### PR DESCRIPTION
(Possibly) fixes #1439 

Not sure if this is the best way to fix it, because in older source code it doesn't have the `?` either, and yet the embed URL worked back then (release-4.0|4.1 branches)

Could someone take a look and test and merge if correct?