### PR TITLE
Remove trimAttributionCount configuration option

### DIFF
--- a/src/content-handlers/iiif/BaseConfig.ts
+++ b/src/content-handlers/iiif/BaseConfig.ts
@@ -156,6 +156,7 @@ export type CenterPanelOptions = {
   subtitleEnabled: boolean;
   mostSpecificRequiredStatement: boolean;
   requiredStatementEnabled: boolean;
+  trimAttributionCount?: number;
 };
 
 export type CenterPanelContent = {

--- a/src/content-handlers/iiif/BaseConfig.ts
+++ b/src/content-handlers/iiif/BaseConfig.ts
@@ -156,7 +156,6 @@ export type CenterPanelOptions = {
   subtitleEnabled: boolean;
   mostSpecificRequiredStatement: boolean;
   requiredStatementEnabled: boolean;
-  trimAttributionCount?: number;
 };
 
 export type CenterPanelContent = {

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/Config.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/Config.ts
@@ -125,8 +125,6 @@ type OpenSeadragonCenterPanelOptions = CenterPanelOptions & {
   showHomeControl: boolean;
   /** Determines if adjust image control is shown */
   showAdjustImageControl: boolean;
-  /** Number of attributions to trim */
-  trimAttributionCount: number;
   /** Ratio of visibility */
   visibilityRatio: number;
   /** Whether to zoom in to first annotation on load */

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
@@ -363,7 +363,7 @@
         "showAdjustImageControl": true,
         "subtitleEnabled": true,
         "titleEnabled": true,
-        "trimAttributionCount": 150,
+        "trimAttributionCount": 500,
         "visibilityRatio": 0.5,
         "zoomToInitialAnnotation": true
       },

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
@@ -363,7 +363,6 @@
         "showAdjustImageControl": true,
         "subtitleEnabled": true,
         "titleEnabled": true,
-        "trimAttributionCount": 500,
         "visibilityRatio": 0.5,
         "zoomToInitialAnnotation": true
       },

--- a/src/content-handlers/iiif/modules/uv-shared-module/CenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/CenterPanel.ts
@@ -211,9 +211,9 @@ export class CenterPanel<
       $attributionText.targetBlank();
     }
 
-    // $attribution.toggleExpandText(this.options.trimAttributionCount, () => {
-    //     this.resize();
-    // });
+    $attributionText.toggleExpandText(this.options.trimAttributionCount, () => {
+        this.resize();
+    });
 
     //if (license){
     //    $license.append('<a href="' + license + '">' + license + '</a>');

--- a/src/content-handlers/iiif/modules/uv-shared-module/CenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/CenterPanel.ts
@@ -211,10 +211,6 @@ export class CenterPanel<
       $attributionText.targetBlank();
     }
 
-    $attributionText.toggleExpandText(this.options.trimAttributionCount, () => {
-        this.resize();
-    });
-
     //if (license){
     //    $license.append('<a href="' + license + '">' + license + '</a>');
     //} else {

--- a/src/content-handlers/iiif/modules/uv-shared-module/CenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/CenterPanel.ts
@@ -212,7 +212,7 @@ export class CenterPanel<
     }
 
     $attributionText.toggleExpandText(this.options.trimAttributionCount, () => {
-        this.resize();
+      this.resize();
     });
 
     //if (license){


### PR DESCRIPTION
This option limits the number of characters displayed in the attribution text (counting characters from the start of the raw HTML string). Trimming too short may prevent images or links from displaying correctly. 

Not sure how useful this actually is; might be better to just remove it? 

Manifest for testing: https://iiif.io/api/cookbook/recipe/0008-rights/manifest.json