### PR TITLE
Fix textLimit issues in MoreInfo

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/MetadataComponent.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/MetadataComponent.ts
@@ -412,15 +412,20 @@ export class MetadataComponent extends BaseComponent {
 
         if (this._data.limit && this._data.content) {
           if (this._data.limitType === LimitType.LINES) {
-            toggleExpandTextByLines(
+            const args = [
               $items,
               this._data.limit,
               this._data.content.less,
               this._data.content.more,
               () => {},
               this._data.content.lessAriaLabelTemplate,
-              this._data.content.moreAriaLabelTemplate
-            );
+              this._data.content.moreAriaLabelTemplate,
+            ];
+
+            // allow time for the sidebar to render
+            setTimeout(() => {
+              toggleExpandTextByLines.apply(this, args);
+            }, 100);
           } else if (this._data.limitType === LimitType.CHARS) {
             $value.ellipsisHtmlFixed(this._data.limit, () => {});
           }


### PR DESCRIPTION
Text limit was trying to measure the height on elements that weren't rendering in the DOM yet (always 0). A slight pause (100ms) seems to resolve this.

Was built off of #1463 for ease - can likely be cherry-picked. Resolves #1464.
