### PR TITLE
Upgrade iiif-metadata-component to v1.2.2.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@iiif/base-component": "2.0.1",
         "@iiif/iiif-av-component": "1.2.4",
         "@iiif/iiif-gallery-component": "^1.1.23",
-        "@iiif/iiif-metadata-component": "^1.2.1",
+        "@iiif/iiif-metadata-component": "^1.2.2",
         "@iiif/iiif-tree-component": "^2.0.7",
         "@iiif/manifold": "^2.1.1",
         "@iiif/presentation-3": "^1.0.5",
@@ -1260,9 +1260,9 @@
       }
     },
     "node_modules/@iiif/iiif-metadata-component": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@iiif/iiif-metadata-component/-/iiif-metadata-component-1.2.1.tgz",
-      "integrity": "sha512-wPDjaazjJdRatuGxqoduW+CYaH2O3VVvaElerxYQ59/0ifo6fBUxo0GMdni7aNA1NU3Qpo86NmYp/GYtyjYe8Q==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@iiif/iiif-metadata-component/-/iiif-metadata-component-1.2.2.tgz",
+      "integrity": "sha512-5Ut+zjlmHlBh64t8qBT7kp465WbZ8cV5+DFi6RQibW9dt1rcSjoHywToOcLxSyV2Uq8DSu9FNZ3Fm+a8SNLaQw==",
       "license": "MIT",
       "dependencies": {
         "@edsilv/jquery-plugins": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@iiif/base-component": "2.0.1",
     "@iiif/iiif-av-component": "1.2.4",
     "@iiif/iiif-gallery-component": "^1.1.23",
-    "@iiif/iiif-metadata-component": "^1.2.1",
+    "@iiif/iiif-metadata-component": "^1.2.2",
     "@iiif/iiif-tree-component": "^2.0.7",
     "@iiif/manifold": "^2.1.1",
     "@iiif/presentation-3": "^1.0.5",


### PR DESCRIPTION
This backports the fix from #1467 so that we can release a fixed UV v4.2.1.

Resolves #1464.