### PR TITLE
Apply linting and formatting to scripts and tests

### DIFF
--- a/__tests__/configuration_options.js
+++ b/__tests__/configuration_options.js
@@ -1,30 +1,46 @@
-describe('Configuration options', () => {
-  describe('thumb cache invalidation', () => {
+describe("Configuration options", () => {
+  describe("thumb cache invalidation", () => {
     beforeEach(async () => {
-      await page.goto('http://localhost:4444/');
-      await page.waitForSelector('#thumb0');
+      await page.goto("http://localhost:4444/");
+      await page.waitForSelector("#thumb0");
     });
-    it.skip('when set to false does not provide timestamp', async () => {
-      await page.evaluate(() => uv.set(
-        { config: { modules: { contentLeftPanel: { options: { thumbsCacheInvalidation: { enabled: false }}}}}}
-      ));
-      await page.waitForSelector('#thumb0');
-      const imageSrc = await page.$eval('#thumb0 img', e => e.src);
-      expect(imageSrc).toEqual( 
+    it.skip("when set to false does not provide timestamp", async () => {
+      await page.evaluate(() =>
+        uv.set({
+          config: {
+            modules: {
+              contentLeftPanel: {
+                options: { thumbsCacheInvalidation: { enabled: false } },
+              },
+            },
+          },
+        })
+      );
+      await page.waitForSelector("#thumb0");
+      const imageSrc = await page.$eval("#thumb0 img", (e) => e.src);
+      expect(imageSrc).toEqual(
         expect.stringMatching(
-          'https://dlcs.io/iiif-img/wellcome/1/ff2085d5-a9c7-412e-9dbe-dda87712228d/full/90,/0/default.jpg'
+          "https://dlcs.io/iiif-img/wellcome/1/ff2085d5-a9c7-412e-9dbe-dda87712228d/full/90,/0/default.jpg"
         )
       );
     });
-    it.skip('has a configurable parameter type', async () => {
-      await page.evaluate(() => uv.set(
-        { config: { modules: { contentLeftPanel: { options: { thumbsCacheInvalidation: { paramType: '#' }}}}}}
-      ));
-      await page.waitForSelector('#thumb0');
-      const imageSrc = await page.$eval('#thumb0 img', e => e.src);
-      expect(imageSrc).toEqual( 
+    it.skip("has a configurable parameter type", async () => {
+      await page.evaluate(() =>
+        uv.set({
+          config: {
+            modules: {
+              contentLeftPanel: {
+                options: { thumbsCacheInvalidation: { paramType: "#" } },
+              },
+            },
+          },
+        })
+      );
+      await page.waitForSelector("#thumb0");
+      const imageSrc = await page.$eval("#thumb0 img", (e) => e.src);
+      expect(imageSrc).toEqual(
         expect.stringContaining(
-          'https://dlcs.io/iiif-img/wellcome/1/ff2085d5-a9c7-412e-9dbe-dda87712228d/full/90,/0/default.jpg#t='
+          "https://dlcs.io/iiif-img/wellcome/1/ff2085d5-a9c7-412e-9dbe-dda87712228d/full/90,/0/default.jpg#t="
         )
       );
     });

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -1,73 +1,84 @@
-test.skip('Configuration options', () => {});
+test.skip("Configuration options", () => {});
 
-const puppeteer = require('puppeteer');
+const puppeteer = require("puppeteer");
 
-describe('Universal Viewer', () => {
+describe("Universal Viewer", () => {
   let browser;
   let page;
 
   beforeAll(async () => {
     browser = await puppeteer.launch();
     page = await browser.newPage();
-    await page.goto('http://localhost:4444');
+    await page.goto("http://localhost:4444");
   });
 
   afterAll(async () => {
     await browser.close();
   });
 
-  it('has the correct page title', async () => {
+  it("has the correct page title", async () => {
     const title = await page.title();
-    expect(title).toBe('Universal Viewer Examples');
+    expect(title).toBe("Universal Viewer Examples");
   });
 
-  it('loads the viewer images', async () => {
-    await page.waitForSelector('#thumb-0');
-    const imageSrc = await page.$eval('#thumb-0 img', e => e.src);
+  it("loads the viewer images", async () => {
+    await page.waitForSelector("#thumb-0");
+    const imageSrc = await page.$eval("#thumb-0 img", (e) => e.src);
     expect(imageSrc).toEqual(
       expect.stringContaining(
-        'https://iiif.wellcomecollection.org/image/b18035723_0001.JP2/full/90,/0/default.jpg'
+        "https://iiif.wellcomecollection.org/image/b18035723_0001.JP2/full/90,/0/default.jpg"
       )
     );
   });
 
-  it('can toggle thumbnail label truncation', async () => {
-    await page.waitForSelector('#truncateThumbnailLabels');
+  it("can toggle thumbnail label truncation", async () => {
+    await page.waitForSelector("#truncateThumbnailLabels");
 
-    const isCheckedBeforeToggle = await page.$eval('#truncateThumbnailLabels', checkbox => checkbox.checked);
+    const isCheckedBeforeToggle = await page.$eval(
+      "#truncateThumbnailLabels",
+      (checkbox) => checkbox.checked
+    );
     expect(isCheckedBeforeToggle).toBe(true);
 
     const labelOverflowBeforeToggle = await page.evaluate(() => {
-        const label = document.querySelector('.thumbsView .thumbs .thumb .info .label');
-        return getComputedStyle(label).overflowX;
+      const label = document.querySelector(
+        ".thumbsView .thumbs .thumb .info .label"
+      );
+      return getComputedStyle(label).overflowX;
     });
-    expect(labelOverflowBeforeToggle).toBe('hidden');
+    expect(labelOverflowBeforeToggle).toBe("hidden");
 
     await page.evaluate(() => {
-        document.querySelector('#truncateThumbnailLabels').click();
+      document.querySelector("#truncateThumbnailLabels").click();
     });
 
-    const isCheckedAfterToggle = await page.$eval('#truncateThumbnailLabels', checkbox => checkbox.checked);
+    const isCheckedAfterToggle = await page.$eval(
+      "#truncateThumbnailLabels",
+      (checkbox) => checkbox.checked
+    );
     expect(isCheckedAfterToggle).toBe(false);
 
     const labelOverflowAfterToggle = await page.evaluate(() => {
-        const label = document.querySelector('.thumbsView .thumbs .thumb .info .label');
-        return getComputedStyle(label).overflowX;
+      const label = document.querySelector(
+        ".thumbsView .thumbs .thumb .info .label"
+      );
+      return getComputedStyle(label).overflowX;
     });
-    expect(labelOverflowAfterToggle).toBe('visible');
+    expect(labelOverflowAfterToggle).toBe("visible");
   });
 
-  it('settings button is visible', async () => {
-
-    await page.waitForSelector('.btn.imageBtn.settings');
+  it("settings button is visible", async () => {
+    await page.waitForSelector(".btn.imageBtn.settings");
 
     const isSettingsButtonVisible = await page.evaluate(() => {
-      const settingsButton = document.querySelector('.btn.imageBtn.settings');
+      const settingsButton = document.querySelector(".btn.imageBtn.settings");
       const style = window.getComputedStyle(settingsButton);
-      return style.getPropertyValue('visibility') !== 'hidden' && style.getPropertyValue('display') !== 'none';
+      return (
+        style.getPropertyValue("visibility") !== "hidden" &&
+        style.getPropertyValue("display") !== "none"
+      );
     });
 
     expect(isSettingsButtonVisible).toBe(true);
   });
 });
-

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "web": "dist/umd/UV.js",
   "scripts": {
     "e2eserve": "npx serve dist -p 4444",
-    "lint-code": "eslint --fix \"./src/**/*.{js,jsx,ts,tsx}\"",
+    "lint-code": "eslint --fix \"./{scripts,src}/**/*.{js,jsx,ts,tsx}\"",
     "lint-styles": "stylelint --fix \"./src/**/*.{less,css}\"",
     "lint": "npm run lint-code && npm run lint-styles",
-    "prettify": "prettier --write \"./src/**/*.{js,jsx,json,css,less,ts,tsx}\"",
+    "prettify": "prettier --write \"./{scripts,src}/**/*.{js,jsx,json,css,less,ts,tsx}\"",
     "fix": "npm run lint && npm run prettify",
     "dev": "npm run start",
     "start": "npx webpack serve -c webpack.dev-server.js",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
   "web": "dist/umd/UV.js",
   "scripts": {
     "e2eserve": "npx serve dist -p 4444",
-    "lint-code": "eslint --fix \"./{scripts,src}/**/*.{js,jsx,ts,tsx}\"",
+    "lint-code": "eslint --fix \"./{__tests__,scripts,src}/**/*.{js,jsx,ts,tsx}\"",
     "lint-styles": "stylelint --fix \"./src/**/*.{less,css}\"",
     "lint": "npm run lint-code && npm run lint-styles",
-    "prettify": "prettier --write \"./{scripts,src}/**/*.{js,jsx,json,css,less,ts,tsx}\"",
+    "prettify": "prettier --write \"./{__tests__,scripts,src}/**/*.{js,jsx,json,css,less,ts,tsx}\" --ignore-path .prettierignore",
     "fix": "npm run lint && npm run prettify",
     "dev": "npm run start",
     "start": "npx webpack serve -c webpack.dev-server.js",

--- a/scripts/validate_locale.ts
+++ b/scripts/validate_locale.ts
@@ -1,171 +1,180 @@
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
 // Read in parameters to choose which type of validation to run
 const args = process.argv.slice(2);
 const runType = args[0];
 
 // Define primary locale
-const primaryLocale = 'en-GB.json';
+const primaryLocale = "en-GB.json";
 
 const checkLocaleUsage = () => {
-    // get a list of all UV extensions
-    const uvExtensions = getUVExtensions();
+  // get a list of all UV extensions
+  const uvExtensions = getUVExtensions();
 
-    // Read primary locale file.
-    const localeData = readLocaleFile(primaryLocale);
-    // replace all values with a 0
-    // we will increment the value for each key found in the extension config files
-    const localeKeys = Object.keys(localeData).reduce((acc, key) => {
-        acc[key] = 0;
-        return acc;
-    }, {});
+  // Read primary locale file.
+  const localeData = readLocaleFile(primaryLocale);
+  // replace all values with a 0
+  // we will increment the value for each key found in the extension config files
+  const localeKeys = Object.keys(localeData).reduce((acc, key) => {
+    acc[key] = 0;
+    return acc;
+  }, {});
 
-    // Loop through all UV extensions.
-    uvExtensions.forEach(extension => {
-        const config = readExtensionConfig(extension);
-        // Recursively extract all locale values from any "content" objects.
-        const contentLocaleValues = extractContentLocaleValues(config);
-        // For each locale value found, if it exists in the primary locale keys, increment its count.
-        contentLocaleValues.forEach(val => {
-            if (val in localeKeys) {
-                localeKeys[val]++;
-            }
-        });
+  // Loop through all UV extensions.
+  uvExtensions.forEach((extension) => {
+    const config = readExtensionConfig(extension);
+    // Recursively extract all locale values from any "content" objects.
+    const contentLocaleValues = extractContentLocaleValues(config);
+    // For each locale value found, if it exists in the primary locale keys, increment its count.
+    contentLocaleValues.forEach((val) => {
+      if (val in localeKeys) {
+        localeKeys[val]++;
+      }
     });
+  });
 
-    console.log("Final locale keys count:", localeKeys);
-    console.log("Unused locale keys:", getUnusedLocaleKeys(localeKeys));
+  console.log("Final locale keys count:", localeKeys);
+  console.log("Unused locale keys:", getUnusedLocaleKeys(localeKeys));
 };
 
-
 const checkHardCodedStrings = () => {
-    const missing = [];
-    // get a list of all UV extensions
-    const uvExtensions = getUVExtensions();
+  const missing = [];
+  // get a list of all UV extensions
+  const uvExtensions = getUVExtensions();
 
-    // Loop through all UV extensions.
-    uvExtensions.forEach(extension => {
-        const config = readExtensionConfig(extension);
-        // Recursively extract all locale values from any "content" objects.
-        const contentLocaleValues = extractContentLocaleValues(config);
-        // For each locale value found, if it exists in the primary locale keys, increment its count.
-        contentLocaleValues.forEach(val => {
-            // if val does not start with $
-            const hasStartingDelimiter = keyStartsWithDollar(val);
-            if (!hasStartingDelimiter) {
-                missing.push({ extension: extension, key: val });
-            }
-        });
+  // Loop through all UV extensions.
+  uvExtensions.forEach((extension) => {
+    const config = readExtensionConfig(extension);
+    // Recursively extract all locale values from any "content" objects.
+    const contentLocaleValues = extractContentLocaleValues(config);
+    // For each locale value found, if it exists in the primary locale keys, increment its count.
+    contentLocaleValues.forEach((val) => {
+      // if val does not start with $
+      const hasStartingDelimiter = keyStartsWithDollar(val);
+      if (!hasStartingDelimiter) {
+        missing.push({ extension: extension, key: val });
+      }
     });
+  });
 
-    console.log("missing locale keys:", missing);
+  console.log("missing locale keys:", missing);
 };
 
 const keyStartsWithDollar = (val) => {
-    if (val.substring(0, 1) !== '$') {
-        return false
-    }
+  if (val.substring(0, 1) !== "$") {
+    return false;
+  }
 
-    return true;
+  return true;
 };
 
 const getUVExtensions = () => {
-    const extensions = [];
-    // get a list of all UV extensions
-    const directoryPath = path.join(__dirname, '../src/content-handlers/iiif/extensions/');
+  const extensions = [];
+  // get a list of all UV extensions
+  const directoryPath = path.join(
+    __dirname,
+    "../src/content-handlers/iiif/extensions/"
+  );
 
-    try {
-        const files = fs.readdirSync(directoryPath);
+  try {
+    const files = fs.readdirSync(directoryPath);
 
-        files.forEach(function (file) {
-            const dir = file.substring(0, 2);
-            // only get directories that start with 'uv'
-            if (dir === 'uv') {
-                extensions.push(file);
-            }
-        });
-    } catch (err) {
-        console.log('Unable to scan directory: ' + err);
-    }
+    files.forEach(function (file) {
+      const dir = file.substring(0, 2);
+      // only get directories that start with 'uv'
+      if (dir === "uv") {
+        extensions.push(file);
+      }
+    });
+  } catch (err) {
+    console.log("Unable to scan directory: " + err);
+  }
 
-    return extensions;
-}
+  return extensions;
+};
 
 const getUVLocales = () => {
-    const localeDir = path.join(__dirname, '../src/locales');
-    const localeFiles = fs.readdirSync(localeDir);
-    return localeFiles;
+  const localeDir = path.join(__dirname, "../src/locales");
+  const localeFiles = fs.readdirSync(localeDir);
+  return localeFiles;
 };
 
 const getUnusedLocaleKeys = (localeKeys) => {
-    return Object.entries(localeKeys).filter(([key, value]) => value === 0);
-}
+  return Object.entries(localeKeys).filter(([key, value]) => value === 0);
+};
 
 // Recursively extract all values in any "content" object that are strings starting with "$"
 const extractContentLocaleValues = (obj) => {
-    let values = [];
-    for (const [prop, value] of Object.entries(obj)) {
-        if (prop === 'content' && typeof value === 'object' && value !== null) {
-            Object.values(value).forEach(item => {
-                if (typeof item === 'string') {
-                    values.push(item);
-                }
-            });
-        } else if (typeof value === 'object' && value !== null) {
-            values = values.concat(extractContentLocaleValues(value));
+  let values = [];
+  for (const [prop, value] of Object.entries(obj)) {
+    if (prop === "content" && typeof value === "object" && value !== null) {
+      Object.values(value).forEach((item) => {
+        if (typeof item === "string") {
+          values.push(item);
         }
+      });
+    } else if (typeof value === "object" && value !== null) {
+      values = values.concat(extractContentLocaleValues(value));
     }
-    return values;
+  }
+  return values;
 };
 
 const readLocaleFile = (lang) => {
-    const localeDir = path.join(__dirname, '../src/locales');
-    const localeFiles = fs.readdirSync(localeDir).filter(file => file.endsWith(`${lang}`));
-    if (localeFiles.length === 0) {
-        throw new Error(`No locale file found for language ${lang}`);
-    }
-    const filePath = path.join(localeDir, localeFiles[0]);
-    const fileContent = fs.readFileSync(filePath, 'utf8');
-    return JSON.parse(fileContent);
+  const localeDir = path.join(__dirname, "../src/locales");
+  const localeFiles = fs
+    .readdirSync(localeDir)
+    .filter((file) => file.endsWith(`${lang}`));
+  if (localeFiles.length === 0) {
+    throw new Error(`No locale file found for language ${lang}`);
+  }
+  const filePath = path.join(localeDir, localeFiles[0]);
+  const fileContent = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(fileContent);
 };
 
 const readExtensionConfig = (extension) => {
-    const configPath = path.join(__dirname, `../src/content-handlers/iiif/extensions/${extension}/config/config.json`);
-    const configContent = fs.readFileSync(configPath, 'utf8');
-    return JSON.parse(configContent);
+  const configPath = path.join(
+    __dirname,
+    `../src/content-handlers/iiif/extensions/${extension}/config/config.json`
+  );
+  const configContent = fs.readFileSync(configPath, "utf8");
+  return JSON.parse(configContent);
 };
 
 const missingTranslations = () => {
-    const primaryLocaleData = readLocaleFile(primaryLocale);
-    const allLocales = getUVLocales();
+  const primaryLocaleData = readLocaleFile(primaryLocale);
+  const allLocales = getUVLocales();
 
-    for (const locale of allLocales) {
-        if (locale === primaryLocale) {
-            continue;
-        }
-        const localeData = readLocaleFile(locale);
-        // Compare primary locale keys with each other locale's keys.
-        // If a key is missing in the other locale, log an error.
-        for (const key of Object.keys(primaryLocaleData)) {
-            if (!(key in localeData)) {
-                console.error(`Key "${key}" missing in locale "${locale}"`);
-            }
-        }
+  for (const locale of allLocales) {
+    if (locale === primaryLocale) {
+      continue;
     }
+    const localeData = readLocaleFile(locale);
+    // Compare primary locale keys with each other locale's keys.
+    // If a key is missing in the other locale, log an error.
+    for (const key of Object.keys(primaryLocaleData)) {
+      if (!(key in localeData)) {
+        console.error(`Key "${key}" missing in locale "${locale}"`);
+      }
+    }
+  }
 };
 
 switch (runType) {
-    case 'checkLocaleUsage':
-        checkLocaleUsage();
-        break;
-    case 'missingTranslations':
-        missingTranslations();
-        break;
-    case 'hardCodedStrings':
-        checkHardCodedStrings();
-        break;
-    default:
-        console.error('No parameter or no valid run type. Please use checkLocaleUsage, missingTranslations or hardCodedStrings');
-        break;
+  case "checkLocaleUsage":
+    checkLocaleUsage();
+    break;
+  case "missingTranslations":
+    missingTranslations();
+    break;
+  case "hardCodedStrings":
+    checkHardCodedStrings();
+    break;
+  default:
+    console.error(
+      "No parameter or no valid run type. Please use checkLocaleUsage, missingTranslations or hardCodedStrings"
+    );
+    break;
 }

--- a/scripts/validate_locale.ts
+++ b/scripts/validate_locale.ts
@@ -2,8 +2,8 @@ const fs = require('fs');
 const path = require('path');
 
 // Read in parameters to choose which type of validation to run
-let args = process.argv.slice(2);
-let runType = args[0];
+const args = process.argv.slice(2);
+const runType = args[0];
 
 // Define primary locale
 const primaryLocale = 'en-GB.json';
@@ -13,19 +13,19 @@ const checkLocaleUsage = () => {
     const uvExtensions = getUVExtensions();
 
     // Read primary locale file.
-    let localeData = readLocaleFile(primaryLocale);
+    const localeData = readLocaleFile(primaryLocale);
     // replace all values with a 0
     // we will increment the value for each key found in the extension config files
-    let localeKeys = Object.keys(localeData).reduce((acc, key) => {
+    const localeKeys = Object.keys(localeData).reduce((acc, key) => {
         acc[key] = 0;
         return acc;
     }, {});
 
     // Loop through all UV extensions.
     uvExtensions.forEach(extension => {
-        let config = readExtensionConfig(extension);
+        const config = readExtensionConfig(extension);
         // Recursively extract all locale values from any "content" objects.
-        let contentLocaleValues = extractContentLocaleValues(config);
+        const contentLocaleValues = extractContentLocaleValues(config);
         // For each locale value found, if it exists in the primary locale keys, increment its count.
         contentLocaleValues.forEach(val => {
             if (val in localeKeys) {
@@ -40,19 +40,19 @@ const checkLocaleUsage = () => {
 
 
 const checkHardCodedStrings = () => {
-    let missing = [];
+    const missing = [];
     // get a list of all UV extensions
     const uvExtensions = getUVExtensions();
 
     // Loop through all UV extensions.
     uvExtensions.forEach(extension => {
-        let config = readExtensionConfig(extension);
+        const config = readExtensionConfig(extension);
         // Recursively extract all locale values from any "content" objects.
-        let contentLocaleValues = extractContentLocaleValues(config);
+        const contentLocaleValues = extractContentLocaleValues(config);
         // For each locale value found, if it exists in the primary locale keys, increment its count.
         contentLocaleValues.forEach(val => {
             // if val does not start with $
-            let hasStartingDelimiter = keyStartsWithDollar(val);
+            const hasStartingDelimiter = keyStartsWithDollar(val);
             if (!hasStartingDelimiter) {
                 missing.push({ extension: extension, key: val });
             }
@@ -71,7 +71,7 @@ const keyStartsWithDollar = (val) => {
 };
 
 const getUVExtensions = () => {
-    let extensions = [];
+    const extensions = [];
     // get a list of all UV extensions
     const directoryPath = path.join(__dirname, '../src/content-handlers/iiif/extensions/');
 
@@ -79,7 +79,7 @@ const getUVExtensions = () => {
         const files = fs.readdirSync(directoryPath);
 
         files.forEach(function (file) {
-            let dir = file.substring(0, 2);
+            const dir = file.substring(0, 2);
             // only get directories that start with 'uv'
             if (dir === 'uv') {
                 extensions.push(file);
@@ -140,14 +140,14 @@ const missingTranslations = () => {
     const primaryLocaleData = readLocaleFile(primaryLocale);
     const allLocales = getUVLocales();
 
-    for (let locale of allLocales) {
+    for (const locale of allLocales) {
         if (locale === primaryLocale) {
             continue;
         }
         const localeData = readLocaleFile(locale);
         // Compare primary locale keys with each other locale's keys.
         // If a key is missing in the other locale, log an error.
-        for (let key of Object.keys(primaryLocaleData)) {
+        for (const key of Object.keys(primaryLocaleData)) {
             if (!(key in localeData)) {
                 console.error(`Key "${key}" missing in locale "${locale}"`);
             }


### PR DESCRIPTION
I realized that our tools were only being applied to the src directory, but it is also worth consistently formatting our stand-alone scripts.

I would also like to apply the same tools to our tests, but for some reason I have so far been unable to figure out how to make that part work -- the tools just ignore the tests no matter what glob or explicit path I use. Not sure what I'm doing wrong!