### PR TITLE
Fix loading of audio/mpeg MIME type (fixes #964).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@iiif/iiif-av-component": "1.2.4",
         "@iiif/manifold": "^2.1.1",
         "@iiif/presentation-3": "^1.0.5",
-        "@iiif/vocabulary": "^1.0.23",
+        "@iiif/vocabulary": "^1.0.28",
         "@openseadragon-imaging/openseadragon-viewerinputhook": "^2.2.1",
         "@universalviewer/aleph": "0.0.21",
         "@universalviewer/uv-ebook-components": "1.0.2",
@@ -1385,9 +1385,10 @@
       }
     },
     "node_modules/@iiif/vocabulary": {
-      "version": "1.0.26",
-      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.26.tgz",
-      "integrity": "sha512-yOsMDg5C90iMfD5HSydoTDzmOM/ki5zGiu4DbHpzRueM7D+12IcDHeai2A8QvEroS8HCJl5M1Edbju5rOlPIpg=="
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.28.tgz",
+      "integrity": "sha512-+6D5FYv5fHvYpJHZKOoX0FYsU/w+cOLKcIrL2lFKkrCoD2LfMf5JzdxvgrAqdcBbwIa3AGJwWaHhXPhYbS40iQ==",
+      "license": "MIT"
     },
     "node_modules/@ionic/core": {
       "version": "4.11.13",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@iiif/iiif-av-component": "1.2.4",
     "@iiif/manifold": "^2.1.1",
     "@iiif/presentation-3": "^1.0.5",
-    "@iiif/vocabulary": "^1.0.23",
+    "@iiif/vocabulary": "^1.0.28",
     "@openseadragon-imaging/openseadragon-viewerinputhook": "^2.2.1",
     "@universalviewer/aleph": "0.0.21",
     "@universalviewer/uv-ebook-components": "1.0.2",

--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -142,6 +142,7 @@ export default class IIIFContentHandler
     this._extensionRegistry[MediaType.GLTF] = Extension.MODELVIEWER;
     this._extensionRegistry[MediaType.JPG] = Extension.OSD;
     this._extensionRegistry[MediaType.MP3] = Extension.AV;
+    this._extensionRegistry[MediaType.MPEG] = Extension.AV;
     this._extensionRegistry[MediaType.MPEG_DASH] = Extension.AV;
     this._extensionRegistry[MediaType.OPF] = Extension.EBOOK;
     this._extensionRegistry[MediaType.PDF] = Extension.PDF;


### PR DESCRIPTION
This PR upgrades to the latest vocabulary library and uses the newly-added MediaType.MPEG to improve MP3 support in the extension registry.