### PR TITLE
Correctly route PNG images to OpenSeadragon.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@iiif/iiif-av-component": "1.2.4",
         "@iiif/manifold": "^2.1.1",
         "@iiif/presentation-3": "^1.0.5",
-        "@iiif/vocabulary": "^1.0.28",
+        "@iiif/vocabulary": "^1.0.29",
         "@openseadragon-imaging/openseadragon-viewerinputhook": "^2.2.1",
         "@universalviewer/aleph": "0.0.21",
         "@universalviewer/uv-ebook-components": "1.0.2",
@@ -1810,9 +1810,9 @@
       }
     },
     "node_modules/@iiif/vocabulary": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.28.tgz",
-      "integrity": "sha512-+6D5FYv5fHvYpJHZKOoX0FYsU/w+cOLKcIrL2lFKkrCoD2LfMf5JzdxvgrAqdcBbwIa3AGJwWaHhXPhYbS40iQ==",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.29.tgz",
+      "integrity": "sha512-mT3bySFvKvmWpjjuzLI2Bd6P+/R2TDF613ADfHy8FI4CNEURJzqCLg5t58eoAK2Ipdwpalvwmc89Xrr2sDHr+w==",
       "license": "MIT"
     },
     "node_modules/@ionic/core": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@iiif/iiif-av-component": "1.2.4",
     "@iiif/manifold": "^2.1.1",
     "@iiif/presentation-3": "^1.0.5",
-    "@iiif/vocabulary": "^1.0.28",
+    "@iiif/vocabulary": "^1.0.29",
     "@openseadragon-imaging/openseadragon-viewerinputhook": "^2.2.1",
     "@universalviewer/aleph": "0.0.21",
     "@universalviewer/uv-ebook-components": "1.0.2",

--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -146,6 +146,7 @@ export default class IIIFContentHandler
     this._extensionRegistry[MediaType.MPEG_DASH] = Extension.AV;
     this._extensionRegistry[MediaType.OPF] = Extension.EBOOK;
     this._extensionRegistry[MediaType.PDF] = Extension.PDF;
+    this._extensionRegistry[MediaType.PNG] = Extension.OSD;
     this._extensionRegistry[MediaType.USDZ] = Extension.MODELVIEWER;
     this._extensionRegistry[MediaType.VIDEO_MP4] = Extension.AV;
     this._extensionRegistry[MediaType.WAV] = Extension.AV;


### PR DESCRIPTION
- Resolves #1511

Here are manifests to test with (which work here but break on the dev branch prior to these changes):

https://iiif.io/api/cookbook/recipe/0004-canvas-size/manifest.json

https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json