### PR TITLE
Improve PDF.js zoom functionality; add configurability

### DIFF
--- a/manual/CONFIG.md
+++ b/manual/CONFIG.md
@@ -905,6 +905,16 @@ Determines whether the most specific (deeply nested) requiredStatement is displa
 **Default**: `true`  
 Determines if the [required statement](https://iiif.io/api/cookbook/recipe/0008-rights/) is enabled.
 
+##### maxScale
+**Type**: `number`
+**Default**: 0.7
+Minimum scale factor to apply to PDFs when using PDF.js.
+
+##### minScale
+**Type**: `number`
+**Default**: 0.7
+Minimum scale factor to apply to PDFs when using PDF.js.
+
 ##### usePdfJs  
 **Type**: `boolean`  
 **Default**: `true`  

--- a/manual/CONFIG.md
+++ b/manual/CONFIG.md
@@ -906,13 +906,13 @@ Determines whether the most specific (deeply nested) requiredStatement is displa
 Determines if the [required statement](https://iiif.io/api/cookbook/recipe/0008-rights/) is enabled.
 
 ##### maxScale
-**Type**: `number`
-**Default**: 0.7
+**Type**: `number`  
+**Default**: 0.7  
 Minimum scale factor to apply to PDFs when using PDF.js.
 
 ##### minScale
-**Type**: `number`
-**Default**: 0.7
+**Type**: `number`  
+**Default**: 0.7  
 Minimum scale factor to apply to PDFs when using PDF.js.
 
 ##### usePdfJs  

--- a/manual/CONFIG.md
+++ b/manual/CONFIG.md
@@ -907,7 +907,7 @@ Determines if the [required statement](https://iiif.io/api/cookbook/recipe/0008-
 
 ##### maxScale
 **Type**: `number`  
-**Default**: 0.7  
+**Default**: 5  
 Minimum scale factor to apply to PDFs when using PDF.js.
 
 ##### minScale

--- a/manual/CONFIG.md
+++ b/manual/CONFIG.md
@@ -908,7 +908,7 @@ Determines if the [required statement](https://iiif.io/api/cookbook/recipe/0008-
 ##### maxScale
 **Type**: `number`  
 **Default**: 5  
-Minimum scale factor to apply to PDFs when using PDF.js.
+Maximum scale factor to apply to PDFs when using PDF.js.
 
 ##### minScale
 **Type**: `number`  

--- a/src/content-handlers/iiif/extensions/uv-pdf-extension/config/Config.ts
+++ b/src/content-handlers/iiif/extensions/uv-pdf-extension/config/Config.ts
@@ -16,6 +16,10 @@ import {
 } from "@/content-handlers/iiif/BaseConfig";
 
 type PDFCenterPanelOptions = CenterPanelOptions & {
+  /** Minimum scale value when using PDF.js */
+  minScale: number;
+  /** Maximum scale value when using PDF.js */
+  maxScale: number;
   /** Determines if PDF.js should be used for PDF rendering */
   usePdfJs: boolean;
 };

--- a/src/content-handlers/iiif/extensions/uv-pdf-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-pdf-extension/config/config.json
@@ -231,6 +231,8 @@
         "subtitleEnabled": true,
         "mostSpecificRequiredStatement": true,
         "requiredStatementEnabled": true,
+        "minScale": 0.7,
+        "maxScale": 5,
         "usePdfJs": true
       },
       "content": {

--- a/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -24,8 +24,6 @@ export class PDFCenterPanel extends CenterPanel<
   private _canvas: HTMLCanvasElement;
   private _ctx: any;
   private _lastMediaUri: string | null = null;
-  private _maxScale = 5;
-  private _minScale = 0.7;
   private _nextButtonEnabled: boolean = false;
   private _pageIndex: number = 1;
   private _pageIndexPending: number | null = null;
@@ -39,6 +37,28 @@ export class PDFCenterPanel extends CenterPanel<
 
   constructor($element: JQuery) {
     super($element);
+  }
+
+  private _getDecreasedScale(): number
+  {
+    return this._scale > 0.5 ? this._scale - 0.5 : this._scale / 1.5;
+  }
+
+  private _getIncreasedScale(): number
+  {
+    return this._scale >= 0.5 ? this._scale + 0.5 : this._scale * 1.5;
+  }
+
+  private _getMinScale(): number
+  {
+    const minScale = Number(this.options.minScale);
+    return minScale > 0 ? minScale : 0.7;
+  }
+
+  private _getMaxScale(): number
+  {
+    const maxScale = Number(this.options.maxScale);
+    return maxScale > 0 ? maxScale : 5;
   }
 
   create(): void {
@@ -170,24 +190,24 @@ export class PDFCenterPanel extends CenterPanel<
     );
 
     this.extensionHost.subscribe(PDFExtensionEvents.ZOOM_IN, () => {
-      const newScale: number = this._scale + 0.5;
-
-      if (newScale < this._maxScale) {
+      const newScale: number = this._getIncreasedScale();
+      const maxScale: number = this._getMaxScale();
+      if (newScale < maxScale) {
         this._scale = newScale;
       } else {
-        this._scale = this._maxScale;
+        this._scale = maxScale;
       }
 
       this._render(this._pageIndex);
     });
 
     this.extensionHost.subscribe(PDFExtensionEvents.ZOOM_OUT, () => {
-      const newScale: number = this._scale - 0.5;
-
-      if (newScale > this._minScale) {
+      const newScale: number = this._getDecreasedScale();
+      const minScale: number = this._getMinScale();
+      if (newScale > minScale) {
         this._scale = newScale;
       } else {
-        this._scale = this._minScale;
+        this._scale = minScale;
       }
 
       this._render(this._pageIndex);
@@ -214,27 +234,11 @@ export class PDFCenterPanel extends CenterPanel<
     this.disableNextButton();
 
     this.onAccessibleClick(this._$zoomInButton, () => {
-      const newScale: number = this._scale + 0.5;
-
-      if (newScale < this._maxScale) {
-        this._scale = newScale;
-      } else {
-        this._scale = this._maxScale;
-      }
-
-      this._render(this._pageIndex);
+      this.extensionHost.publish(PDFExtensionEvents.ZOOM_IN);
     });
 
     this.onAccessibleClick(this._$zoomOutButton, () => {
-      const newScale: number = this._scale - 0.5;
-
-      if (newScale > this._minScale) {
-        this._scale = newScale;
-      } else {
-        this._scale = this._minScale;
-      }
-
-      this._render(this._pageIndex);
+      this.extensionHost.publish(PDFExtensionEvents.ZOOM_OUT);
     });
   }
 
@@ -362,12 +366,12 @@ export class PDFCenterPanel extends CenterPanel<
     this._$zoomInButton.enable();
 
     //disable zoom if not possible
-    const lowScale: number = this._scale - 0.5;
-    const highScale: number = this._scale + 0.5;
-    if (lowScale < this._minScale) {
+    const lowScale: number = this._getDecreasedScale();
+    const highScale: number = this._getIncreasedScale();
+    if (lowScale < this._getMinScale()) {
       this._$zoomOutButton.disable();
     }
-    if (highScale > this._maxScale) {
+    if (highScale > this._getMaxScale()) {
       this._$zoomInButton.disable();
     }
 

--- a/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -39,24 +39,20 @@ export class PDFCenterPanel extends CenterPanel<
     super($element);
   }
 
-  private _getDecreasedScale(): number
-  {
+  private _getDecreasedScale(): number {
     return this._scale > 0.5 ? this._scale - 0.5 : this._scale / 1.5;
   }
 
-  private _getIncreasedScale(): number
-  {
+  private _getIncreasedScale(): number {
     return this._scale >= 0.5 ? this._scale + 0.5 : this._scale * 1.5;
   }
 
-  private _getMinScale(): number
-  {
+  private _getMinScale(): number {
     const minScale = Number(this.options.minScale);
     return minScale > 0 ? minScale : 0.7;
   }
 
-  private _getMaxScale(): number
-  {
+  private _getMaxScale(): number {
     const maxScale = Number(this.options.maxScale);
     return maxScale > 0 ? maxScale : 5;
   }


### PR DESCRIPTION
There were several problems with PDF.js zoom functionality:

- Logic for applying zoom was duplicated in two places
- There was no way to configure zoom limits
- Scaling worked with a simple addition/subtraction mechanism which made it impossible to zoom out far enough on very large documents

This PR fixes the issues:

- It eliminates redundant code and uses events more consistently
- It adds new config settings for minimum and maximum scale
- It retains the legacy "add or subtract 0.5" scaling functionality, but it adds a "multiply or divide by 1.5" behavior to allow more granular behavior at the extremes

I'm sure there is room for further improvement, especially in terms of the algorithm for zooming, but at least this code centralizes everything into support methods that can be more easily customized and changed in future.

Here is a good manifest for testing purposes:

https://digital.library.villanova.edu/Item/vudl:189057/Manifest

This contains a very large PDF -- you can't zoom out far enough to see the whole thing on screen at once with the default settings, but if you adjust the new config parameters, you can view it more comfortably.