### PR TITLE
Issue 1503, fix continuous behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@google/model-viewer": "^4.0.0",
         "@iiif/base-component": "2.0.1",
         "@iiif/iiif-av-component": "1.2.4",
-        "@iiif/manifold": "^2.1.1",
+        "@iiif/manifold": "^2.1.3",
         "@iiif/presentation-3": "^1.0.5",
         "@iiif/vocabulary": "^1.0.29",
         "@openseadragon-imaging/openseadragon-viewerinputhook": "^2.2.1",
@@ -1309,9 +1309,9 @@
       }
     },
     "node_modules/@iiif/manifold": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-2.1.2.tgz",
-      "integrity": "sha512-odunugOfwagjDzJvYdhlrRrZ5C8nNoaxNH7FTcgORalu0H9nufVXmWSMIKbDpdCY2kRURW+7F3aKgKuu4sZS2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@iiif/manifold/-/manifold-2.1.3.tgz",
+      "integrity": "sha512-vOdXo/j3zew0kRSqKxXDVNg4fDS8JygkTlrnCepAxbz/HVyCUTiVlh38rUimYLEWDEGU2LymmSof+PGk3uPuLA==",
       "license": "MIT",
       "dependencies": {
         "@edsilv/http-status-codes": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "@google/model-viewer": "^4.0.0",
     "@iiif/base-component": "2.0.1",
     "@iiif/iiif-av-component": "1.2.4",
-    "@iiif/manifold": "^2.1.1",
+    "@iiif/manifold": "^2.1.3",
     "@iiif/presentation-3": "^1.0.5",
     "@iiif/vocabulary": "^1.0.29",
     "@openseadragon-imaging/openseadragon-viewerinputhook": "^2.2.1",

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
@@ -1581,7 +1581,7 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
     let indices: number[] = [];
 
     // if it's a continuous manifest, get all resources.
-    if (sequence.getViewingHint() === ViewingHint.CONTINUOUS) {
+    if (this.helper.isContinuous()) {
       // get all canvases to be displayed inline
       indices = canvases.map((_canvas: Canvas, index: number) => {
         return index;

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -1576,19 +1576,6 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
         }, 200);
       }
     }
-
-    // stretch navigator, allowing time for OSD to resize
-    // setTimeout(() => {
-    //   if (this.extension.helper.isContinuous()) {
-    //     if (this.extension.helper.isHorizontallyAligned()) {
-    //       const width: number =
-    //         this.$viewer.width() - this.$viewer.rightMargin();
-    //       this.$navigator.width(width);
-    //     } else {
-    //       this.$navigator.height(this.$viewer.height());
-    //     }
-    //   }
-    // }, 100);
   }
 
   setFocus(): void {

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -951,20 +951,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     let navigatorWidth: number;
     let navigatorHeight: number;
 
-    if (this.extension.helper.isHorizontallyAligned()) {
-      navigatorWidth = viewportWidth;
-      navigatorHeight = navigatorWidth / contentAspectRatio;
-
-      // Enforce max height
-      if (navigatorHeight > maxNavigatorHeight) {
-        navigatorHeight = maxNavigatorHeight;
-      }
-
-      // Enforce min height
-      if (navigatorHeight < minHorizontalNavigatorHeight) {
-        navigatorHeight = minHorizontalNavigatorHeight;
-      }
-    } else {
+    if (this.extension.helper.isVerticallyAligned()) {
       navigatorHeight = viewportHeight - this.$zoomInButton.height() - 4;
       navigatorWidth = navigatorHeight * contentAspectRatio;
 
@@ -976,6 +963,19 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       // Enforce min width
       if (navigatorWidth < minVerticalNavigatorWidth) {
         navigatorWidth = minVerticalNavigatorWidth;
+      }
+    } else {
+      navigatorWidth = viewportWidth;
+      navigatorHeight = navigatorWidth / contentAspectRatio;
+
+      // Enforce max height
+      if (navigatorHeight > maxNavigatorHeight) {
+        navigatorHeight = maxNavigatorHeight;
+      }
+
+      // Enforce min height
+      if (navigatorHeight < minHorizontalNavigatorHeight) {
+        navigatorHeight = minHorizontalNavigatorHeight;
       }
     }
 

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -251,10 +251,13 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       maxZoomPixelRatio: this.config.options.maxZoomPixelRatio || 2,
       controlsFadeDelay: this.config.options.controlsFadeDelay || 250,
       controlsFadeLength: this.getControlsFadeLength(),
-      navigatorPosition:
-        this.config.options.navigatorPosition || "BOTTOM_RIGHT",
+      navigatorPosition: this.extension.helper.isContinuous()
+        ? "BOTTOM_LEFT"
+        : this.config.options.navigatorPosition || "BOTTOM_RIGHT",
       navigatorHeight: "100px",
       navigatorWidth: "100px",
+      navigatorMaintainSizeRatio: false,
+      navigatorAutoResize: false,
       animationTime: this.config.options.animationTime || 1.2,
       visibilityRatio: this.config.options.visibilityRatio || 0.5,
       constrainDuringPan: Bools.getBool(
@@ -912,6 +915,13 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.setNavigatorVisible();
 
+    // resize navigator for continuous manifests
+    if (this.extension.helper.isContinuous()) {
+      setTimeout(() => {
+        this.resizeNavigatorForContinuous();
+      }, 200);
+    }
+
     this.overlayAnnotations();
 
     this.updateBounds();
@@ -923,6 +933,58 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     }
 
     this.isFirstLoad = false;
+  }
+
+  private resizeNavigatorForContinuous(): void {
+    if (!this.viewer || !this.viewer.navigator) return;
+
+    const homeBounds = this.viewer.world.getHomeBounds();
+    const contentAspectRatio = homeBounds.width / homeBounds.height;
+
+    const viewportWidth = this.$viewer.width();
+    const viewportHeight = this.$viewer.height();
+    const maxNavigatorWidth = 100;
+    const maxNavigatorHeight = 100;
+    const minVerticalNavigatorWidth = 60;
+    const minHorizontalNavigatorHeight = 40;
+
+    let navigatorWidth: number;
+    let navigatorHeight: number;
+
+    if (this.extension.helper.isHorizontallyAligned()) {
+      navigatorWidth = viewportWidth;
+      navigatorHeight = navigatorWidth / contentAspectRatio;
+
+      // Enforce max height
+      if (navigatorHeight > maxNavigatorHeight) {
+        navigatorHeight = maxNavigatorHeight;
+      }
+
+      // Enforce min height
+      if (navigatorHeight < minHorizontalNavigatorHeight) {
+        navigatorHeight = minHorizontalNavigatorHeight;
+      }
+    } else {
+      navigatorHeight = viewportHeight - this.$zoomInButton.height() - 4;
+      navigatorWidth = navigatorHeight * contentAspectRatio;
+
+      // Enforce max width
+      if (navigatorWidth > maxNavigatorWidth) {
+        navigatorWidth = maxNavigatorWidth;
+      }
+
+      // Enforce min width
+      if (navigatorWidth < minVerticalNavigatorWidth) {
+        navigatorWidth = minVerticalNavigatorWidth;
+      }
+    }
+
+    const navigatorElement = this.viewer.navigator.element;
+    navigatorElement.style.width = `${navigatorWidth}px`;
+    navigatorElement.style.height = `${navigatorHeight}px`;
+
+    this.viewer.navigator.viewport.fitBounds(homeBounds, true);
+    this.viewer.navigator.updateSize();
   }
 
   zoomToInitialAnnotation(): void {
@@ -1506,20 +1568,27 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
           );
           break;
       }
+
+      // resize navigator for continuous manifests
+      if (this.extension.helper.isContinuous()) {
+        setTimeout(() => {
+          this.resizeNavigatorForContinuous();
+        }, 200);
+      }
     }
 
     // stretch navigator, allowing time for OSD to resize
-    setTimeout(() => {
-      if (this.extension.helper.isContinuous()) {
-        if (this.extension.helper.isHorizontallyAligned()) {
-          const width: number =
-            this.$viewer.width() - this.$viewer.rightMargin();
-          this.$navigator.width(width);
-        } else {
-          this.$navigator.height(this.$viewer.height());
-        }
-      }
-    }, 100);
+    // setTimeout(() => {
+    //   if (this.extension.helper.isContinuous()) {
+    //     if (this.extension.helper.isHorizontallyAligned()) {
+    //       const width: number =
+    //         this.$viewer.width() - this.$viewer.rightMargin();
+    //       this.$navigator.width(width);
+    //     } else {
+    //       this.$navigator.height(this.$viewer.height());
+    //     }
+    //   }
+    // }, 100);
   }
 
   setFocus(): void {

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -31,7 +31,6 @@ import {
   Manifest,
   Range,
 } from "manifesto.js";
-// import { ViewingHint } from "@iiif/vocabulary/dist-commonjs/";
 import * as KeyCodes from "../../KeyCodes";
 import {
   Bools,

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExtension.ts
@@ -31,7 +31,7 @@ import {
   Manifest,
   Range,
 } from "manifesto.js";
-import { ViewingHint } from "@iiif/vocabulary/dist-commonjs/";
+// import { ViewingHint } from "@iiif/vocabulary/dist-commonjs/";
 import * as KeyCodes from "../../KeyCodes";
 import {
   Bools,
@@ -1091,12 +1091,7 @@ export class BaseExtension<T extends BaseConfig> implements IExtension {
       if (this.helper.hasParentCollection()) {
         return true;
       } else if (this.helper.isMultiCanvas()) {
-        const viewingHint: ViewingHint | null = this.helper.getViewingHint();
-
-        if (
-          !viewingHint ||
-          (viewingHint && viewingHint !== ViewingHint.CONTINUOUS)
-        ) {
+        if (!this.helper.isContinuous()) {
           return true;
         }
       }


### PR DESCRIPTION

This still needs work and lots of testing so I'll leave it in draft. 

This addresses https://github.com/UniversalViewer/universalviewer/issues/1503, where some Presentation v2 'continuous' manifests, and all Presentation v3 continuous manifests, weren't displaying as continuous scrolls (i.e. all canvases stitched together).

The problem with the v2 manifests supplied in the issue was that UV was only checking for continuous viewingHints on the sequence level, not manifest level.

I've updated the 'isContinuous' method in Manifold to check both viewingHint (v2) and behavior (v3), and both range/sequence level, and manifest level: https://github.com/IIIF-Commons/manifold/pull/64. So this PR can just use isContinuous to check and display all the canvases at once (rather than viewingHint as before).

This resulted in some glitches in the viewport navigation window (OSD's little map of the whole canvas in the bottom right). This was caused by some code in OpenSeadragonCenterPanel.ts that deliberately resized the viewport navigation for continuous manifests, presumably to make the long scroll format fit more neatly into a long thin viewport. I've rewritten this resizing stuff (currently the minimum and maximum widths/heights are hard-coded).

I've also moved the viewport navigation to the left hand side for vertical continuous manifests. There was a bit of code to hide the thumbnail panel for continuous manifests (also now using isContinuous rather than viewingHint), presumably because with this kind of material the long viewport navigation does the job thumbnail navigation was doing for non-continuous content, so it makes sense for it to be where the thumbnails normally are (and not clash with the right panel too). But the current positioning with the title and the zoom buttons looks bad; it should really be to the left of the title and the buttons (like the left panel usually is), so I'll come back to that.

Some manifests for testing:

- Cookbook (v3, continuous behavior, horizontal): https://iiif.io/api/cookbook/recipe/0011-book-3-behavior/manifest-continuous.json
- The original UCLA scroll from issue 1503 (v2, continuous viewingHint, vertical): https://iiif.library.ucla.edu/ark%3A%2F21198%2Fzz001nwthk/manifest
- Mahabharata mega scroll (v2, continuous viewingHint, vertical): https://librarylabs.ed.ac.uk/iiif/manifest/mahabharataFinal.json
- IDP scroll (v2, continuous viewingHint, horizontal): https://data.idp.bl.uk/iiif/3/manifest/967B14BF8CFF43A3B12837F2829B7BAE