### PR TITLE
Avoid disabling all downloads on high res disable

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -264,12 +264,12 @@ const DownloadDialogue = ({
         }
 
         return !paged;
-      case DownloadOption.CANVAS_RENDERINGS:
-      case DownloadOption.IMAGE_RENDERINGS:
       case DownloadOption.WHOLE_IMAGE_HIGH_RES:
         if (!downloadWholeImageHighResEnabled) {
           return false;
         }
+      case DownloadOption.CANVAS_RENDERINGS:
+      case DownloadOption.IMAGE_RENDERINGS:
 
         const maxDimensions: Size | null = canvas.getMaxDimensions();
 

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -265,6 +265,7 @@ const DownloadDialogue = ({
 
         return !paged;
       case DownloadOption.WHOLE_IMAGE_HIGH_RES:
+        // If high-res download is disabled, bail out now; otherwise drop into cases below.
         if (!downloadWholeImageHighResEnabled) {
           return false;
         }

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -270,7 +270,6 @@ const DownloadDialogue = ({
         }
       case DownloadOption.CANVAS_RENDERINGS:
       case DownloadOption.IMAGE_RENDERINGS:
-
         const maxDimensions: Size | null = canvas.getMaxDimensions();
 
         if (maxDimensions) {


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->
https://github.com/UniversalViewer/universalviewer/issues/1526
#### Description of what you did:
When disabling high res downloads in openseadragon, *all* downloads get disabled due to how these cases are grouped - instead, move the high res check up and allow fallthrough if it is enabled.

To test, I first repro'd the bug I'm seeing locally with the provided npm example. I used this manifest: https://qa-api-collections.nypl.org/manifests/510d47e3-2b96-a3d9-e040-e00a18064a99 (so that it would have canvas renderings for download). On the dev branch, if you set high res to true, but everything else as false, it works as expected:
<img width="1196" height="669" alt="Screen Shot 2025-08-15 at 3 21 22 PM" src="https://github.com/user-attachments/assets/a3145cb7-be39-4a4d-9dcf-d5bd88ec0112" />

However, if you flip high res to false, *everything* disappears:
<img width="1190" height="634" alt="Screen Shot 2025-08-15 at 3 21 49 PM" src="https://github.com/user-attachments/assets/1be84197-4213-4716-a398-a31f8eac7854" />

After my change, setting high res to false still lets the manifest provided downloads show up:
<img width="1228" height="648" alt="Screen Shot 2025-08-15 at 3 22 56 PM" src="https://github.com/user-attachments/assets/041d77cd-505b-439b-b194-03907cf7885c" />

