### PR TITLE
Fire IIIF.DOWNLOAD for openseadragon downloads

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -36,6 +36,7 @@ const DownloadDialogue = ({
   maxImageWidth,
   mediaDownloadEnabled,
   onClose,
+  onDownload,
   onDownloadCurrentView,
   onDownloadSelection,
   onShowTermsOfUse,
@@ -64,6 +65,7 @@ const DownloadDialogue = ({
   maxImageWidth: number;
   mediaDownloadEnabled: boolean;
   onClose: () => void;
+  onDownload: (type: DownloadOption, label: string) => void;
   onDownloadCurrentView: (canvas: Canvas) => void;
   onDownloadSelection: () => void;
   onShowTermsOfUse: () => void;
@@ -474,9 +476,11 @@ const DownloadDialogue = ({
   function Renderings({
     resource,
     defaultLabel,
+    type,
   }: {
     resource: ManifestResource;
     defaultLabel: string;
+    type: DownloadOption;
   }) {
     const renderings: Rendering[] = resource.getRenderings();
 
@@ -504,6 +508,7 @@ const DownloadDialogue = ({
             <li key={index}>
               <button
                 onClick={() => {
+                  onDownload(type, label);
                   window.open(rendering.id, "_blank");
                 }}
               >
@@ -530,6 +535,7 @@ const DownloadDialogue = ({
             resource={range}
             defaultLabel={content.entireFileAsOriginal}
             key={`range-rendering-${String(index)}`}
+            type={DownloadOption.RANGE_RENDERINGS}
           />
         ))}
       </>
@@ -547,6 +553,7 @@ const DownloadDialogue = ({
             resource={image.getResource()}
             defaultLabel={content.entireFileAsOriginal}
             key={`image-rendering-${String(index)}`}
+            type={DownloadOption.IMAGE_RENDERINGS}
           />
         ))}
       </>
@@ -560,6 +567,7 @@ const DownloadDialogue = ({
       <Renderings
         resource={canvas}
         defaultLabel={content.entireFileAsOriginal}
+        type={DownloadOption.CANVAS_RENDERINGS}
       />
     );
   }
@@ -576,10 +584,12 @@ const DownloadDialogue = ({
         <Renderings
           resource={sequence}
           defaultLabel={content.entireFileAsOriginal}
+          type={DownloadOption.MANIFEST_RENDERINGS}
         />
         <Renderings
           resource={manifest}
           defaultLabel={content.entireFileAsOriginal}
+          type={DownloadOption.MANIFEST_RENDERINGS}
         />
       </>
     );
@@ -641,6 +651,10 @@ const DownloadDialogue = ({
               <li className="option single">
                 <button
                   onClick={() => {
+                    onDownload(
+                      DownloadOption.CURRENT_VIEW,
+                      getCurrentViewLabel()
+                    );
                     onDownloadCurrentView(getSelectedCanvas());
                   }}
                 >
@@ -652,6 +666,10 @@ const DownloadDialogue = ({
               <li className="option single">
                 <button
                   onClick={() => {
+                    onDownload(
+                      DownloadOption.WHOLE_IMAGES_HIGH_RES,
+                      getWholeImageHighResLabel()
+                    );
                     window.open(getCanvasHighResImageUri(getSelectedCanvas()));
                   }}
                 >
@@ -663,6 +681,10 @@ const DownloadDialogue = ({
               <li className="option single">
                 <button
                   onClick={() => {
+                    onDownload(
+                      DownloadOption.WHOLE_IMAGE_LOW_RES,
+                      getWholeImageLowResLabel()
+                    );
                     const imageUri: string | null =
                       getConfinedImageUri(getSelectedCanvas());
 
@@ -697,6 +719,7 @@ const DownloadDialogue = ({
               <li className="option single">
                 <button
                   onClick={() => {
+                    onDownload(DownloadOption.SELECTION, content.selection);
                     onDownloadSelection();
                   }}
                 >

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
@@ -1,6 +1,7 @@
 import { IIIFEvents } from "../../IIIFEvents";
 import { BaseExtension } from "../../modules/uv-shared-module/BaseExtension";
 import { Bookmark } from "../../modules/uv-shared-module/Bookmark";
+import { DownloadOption } from "../../modules/uv-shared-module/DownloadOption";
 import { XYWHFragment } from "../../modules/uv-shared-module/XYWHFragment";
 import { ContentLeftPanel } from "../../modules/uv-contentleftpanel-module/ContentLeftPanel";
 import { CroppedImageDimensions } from "./CroppedImageDimensions";
@@ -690,6 +691,12 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
         },
         onClose: () => {
           this.closeActiveDialogue();
+        },
+        onDownload: (type: DownloadOption, label: string) => {
+          this.extensionHost.publish(IIIFEvents.DOWNLOAD, {
+            type: type,
+            label: label,
+          });
         },
         onDownloadCurrentView: (canvas: Canvas) => {
           const viewer: any = this.getViewer();


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->
https://github.com/UniversalViewer/universalviewer/issues/1523
#### Description of what you did:
open to feedback on how this is implemented or if this makes sense at all, tried to follow existing patterns in this extension!

Pass an `onDownload` callback to the download dialogue for openseadragon that simply publishes a DOWNLOAD event when one of the download options is clicked.  I enmulated the payload for the DOWNLOAD event for the AV extension:
https://github.com/UniversalViewer/universalviewer/blob/8eeee2452f4fc4d22777fdffcf3ac9d60e2bdd32/src/content-handlers/iiif/extensions/uv-av-extension/DownloadDialogue.ts#L76-L79



