### PR TITLE
Add  OSD zoom button constraints

### DIFF
--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -373,6 +373,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     this.$zoomInButton.addClass("zoomIn viewportNavButton");
 
     this.onAccessibleClick(this.$zoomInButton, () => {
+      if (this.viewer.viewport.getZoom() < this.viewer.viewport.getMaxZoom())
       this.zoomIn();
     });
 
@@ -386,6 +387,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     this.$zoomOutButton.addClass("zoomOut viewportNavButton");
 
     this.onAccessibleClick(this.$zoomOutButton, () => {
+      if (this.viewer.viewport.getZoom() > this.viewer.viewport.getMinZoom())
       this.zoomOut();
     });
 

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -374,7 +374,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.onAccessibleClick(this.$zoomInButton, () => {
       if (this.viewer.viewport.getZoom() < this.viewer.viewport.getMaxZoom())
-      this.zoomIn();
+        this.zoomIn();
     });
 
     const $oldZoomOut = this.$viewer.find('div[title="Zoom out"]');
@@ -388,7 +388,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.onAccessibleClick(this.$zoomOutButton, () => {
       if (this.viewer.viewport.getZoom() > this.viewer.viewport.getMinZoom())
-      this.zoomOut();
+        this.zoomOut();
     });
 
     const $oldGoHome = this.$viewer.find('div[title="Go home"]');


### PR DESCRIPTION
Fixes #1299 - the + and - zoom buttons for OSD manifests now respect zoom limits set by the maxZoomPixelRatio config setting. 
