### PR TITLE
Update vocabulary and register A/V OGG types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@iiif/iiif-av-component": "1.2.4",
         "@iiif/manifold": "^2.1.1",
         "@iiif/presentation-3": "^1.0.5",
-        "@iiif/vocabulary": "^1.0.29",
+        "@iiif/vocabulary": "^1.0.31",
         "@openseadragon-imaging/openseadragon-viewerinputhook": "^2.2.1",
         "@universalviewer/aleph": "0.0.21",
         "@universalviewer/uv-ebook-components": "1.0.2",
@@ -1790,9 +1790,9 @@
       }
     },
     "node_modules/@iiif/vocabulary": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.29.tgz",
-      "integrity": "sha512-mT3bySFvKvmWpjjuzLI2Bd6P+/R2TDF613ADfHy8FI4CNEURJzqCLg5t58eoAK2Ipdwpalvwmc89Xrr2sDHr+w==",
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@iiif/vocabulary/-/vocabulary-1.0.31.tgz",
+      "integrity": "sha512-j2Y/WKRgyHGO7VkQYg2JPJk6XSdYcZ51J/NHnMygeOAo7rSLVHT9B97+tYlYMqV3Z7EBpXID/zeS5Gn12cyUAA==",
       "license": "MIT"
     },
     "node_modules/@ionic/core": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@iiif/iiif-av-component": "1.2.4",
     "@iiif/manifold": "^2.1.1",
     "@iiif/presentation-3": "^1.0.5",
-    "@iiif/vocabulary": "^1.0.29",
+    "@iiif/vocabulary": "^1.0.31",
     "@openseadragon-imaging/openseadragon-viewerinputhook": "^2.2.1",
     "@universalviewer/aleph": "0.0.21",
     "@universalviewer/uv-ebook-components": "1.0.2",

--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -134,6 +134,7 @@ export default class IIIFContentHandler
     this._extensionRegistry[ExternalResourceType.SOUND] =
       Extension.MEDIAELEMENT;
     this._extensionRegistry[MediaType.AUDIO_MP4] = Extension.AV;
+    this._extensionRegistry[MediaType.AUDIO_OGG] = Extension.AV;
     this._extensionRegistry[MediaType.DICOM] = Extension.ALEPH;
     this._extensionRegistry[MediaType.DRACO] = Extension.MODELVIEWER;
     this._extensionRegistry[MediaType.EPUB] = Extension.EBOOK;
@@ -149,6 +150,7 @@ export default class IIIFContentHandler
     this._extensionRegistry[MediaType.PNG] = Extension.OSD;
     this._extensionRegistry[MediaType.USDZ] = Extension.MODELVIEWER;
     this._extensionRegistry[MediaType.VIDEO_MP4] = Extension.AV;
+    this._extensionRegistry[MediaType.VIDEO_OGG] = Extension.AV;
     this._extensionRegistry[MediaType.WAV] = Extension.AV;
     this._extensionRegistry[MediaType.WEBM] = Extension.AV;
     this._extensionRegistry[RenderingFormat.PDF] = Extension.PDF;


### PR DESCRIPTION
This commit will update the [@iiif/vocabulary](https://github.com/IIIF-Commons/vocabulary/) to the latest release (1.0.31) which adds support for audio/ogg and video/ogg and also add OGG to the registry.

Ref:
- https://github.com/IIIF-Commons/vocabulary/pull/32