### PR TITLE
Fix thumbnail alignment in PDF extension

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/css/thumbs-view.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/thumbs-view.less
@@ -83,6 +83,14 @@
         max-width: 100%;
       }
 
+      .thumbsView .thumbs .thumb:focus {
+        outline: none; 
+      }
+
+      .thumbsView .thumbs .thumb:focus-visible {
+        border: 1px solid @link-color;
+      }
+
       .thumbsView .thumbs .thumb .info .label {
         float: left;
         overflow-x: visible;
@@ -113,7 +121,10 @@
       }
 
       .thumbsView .thumbs .thumb.oneCol {
-        margin: 0 0 7px;
+        display: grid;
+        grid-template-columns: 93px 1fr; 
+        gap: 1px;
+        align-items: start;
       }
 
       .thumbsView .thumbs .thumb.oneCol .label {

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/thumbs-view.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/thumbs-view.less
@@ -84,7 +84,7 @@
       }
 
       .thumbsView .thumbs .thumb:focus {
-        outline: none; 
+        outline: none;
       }
 
       .thumbsView .thumbs .thumb:focus-visible {
@@ -122,7 +122,7 @@
 
       .thumbsView .thumbs .thumb.oneCol {
         display: grid;
-        grid-template-columns: 93px 1fr; 
+        grid-template-columns: 93px 1fr;
         gap: 1px;
         align-items: start;
       }


### PR DESCRIPTION
Fixes issue #1529 by adding a grid for one column thumbnails.
I also adjusted the thumbnail focus styling as previously when a PDF thumbnail or label was clicked on they were both outlined with a separating line between them, so now only the thumbnail is outlined but tabbing highlights them both as one unit which is how it works for OSD
