### PR TITLE
Add missing labels to zoom buttons in PDF center panel (fixes #1346)

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-pdf-extension/config/Config.ts
+++ b/src/content-handlers/iiif/extensions/uv-pdf-extension/config/Config.ts
@@ -27,6 +27,8 @@ type PDFCenterPanelOptions = CenterPanelOptions & {
 type PDFCenterPanelContent = CenterPanelContent & {
   next: string;
   previous: string;
+  zoomIn: string;
+  zoomOut: string;
 };
 
 type PDFCenterPanel = {

--- a/src/content-handlers/iiif/extensions/uv-pdf-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-pdf-extension/config/config.json
@@ -240,7 +240,9 @@
         "close": "$close",
         "closeAttribution": "$closeAttribution",
         "next": "$next",
-        "previous": "$previous"
+        "previous": "$previous",
+        "zoomIn": "$zoomIn",
+        "zoomOut": "$zoomOut"
       }
     },
     "resourcesLeftPanel": {

--- a/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -83,9 +83,13 @@ export class PDFCenterPanel extends CenterPanel<
     this._$zoomInButton = $(
       '<button class="btn zoomIn" tabindex="0"></button>'
     );
+    this._$zoomInButton.attr("title", this.content.zoomIn);
+    this._$zoomInButton.attr("aria-label", this.content.zoomIn);
     this._$zoomOutButton = $(
       '<button class="btn zoomOut" tabindex="0"></button>'
     );
+    this._$zoomOutButton.attr("title", this.content.zoomOut);
+    this._$zoomOutButton.attr("aria-label", this.content.zoomOut);
 
     // Only attach PDF controls if we're using PDF.js; they have no meaning in
     // PDFObject. However, we still create the objects above so that references

--- a/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pdfcenterpanel-module/PDFCenterPanel.ts
@@ -365,7 +365,7 @@ export class PDFCenterPanel extends CenterPanel<
     this._$zoomOutButton.enable();
     this._$zoomInButton.enable();
 
-    //disable zoom if not possible
+    // disable zoom if not possible
     const lowScale: number = this._getDecreasedScale();
     const highScale: number = this._getIncreasedScale();
     if (lowScale < this._getMinScale()) {


### PR DESCRIPTION
This adds labels to address #1346.