### PR TITLE
Revert stylelint change that broke build-es task.

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,6 +5,7 @@
   "rules": {
     "block-no-empty": true,
     "at-rule-no-unknown": null,
+    "color-function-notation": null,
     "color-no-invalid-hex": true,
     "less/color-no-invalid-hex": null,
     "rule-empty-line-before": null,

--- a/src/content-handlers/iiif/modules/uv-shared-module/css/scaffolding.less
+++ b/src/content-handlers/iiif/modules/uv-shared-module/css/scaffolding.less
@@ -32,7 +32,7 @@
   padding: 0;
   height: 100%;
 
-  -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0%);
 
   font-family: @font-family-base;
   font-size: @font-size-base;


### PR DESCRIPTION
While working on 4.3.0-rc2, I ran into a problem with the build-es npm script that was solved by reverting this LESS change and disabling a stylelint rule. I don't fully understand the nature of the problem, but this at least allows the build to succeed.