### PR TITLE
Tolerate missing annotationUri.

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-mediaelement-extension/Extension.ts
+++ b/src/content-handlers/iiif/extensions/uv-mediaelement-extension/Extension.ts
@@ -280,7 +280,7 @@ export default class Extension
         if (typeof annotationUri === "string") {
           posterUri = annotationUri;
         } else if (
-          annotationUri.length &&
+          annotationUri?.length &&
           typeof annotationUri[0].id === "string"
         ) {
           posterUri = annotationUri[0].id;


### PR DESCRIPTION
This should fix the problem reported by #1632. It was introduced by #1603, which made an unsafe assumption about the annotationUri variable. Sorry for not catching that earlier -- we should have tested a broader range of manifests when working on that PR.