### PR TITLE
Fix 'All Pages' download for v3 manifests.

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -574,7 +574,7 @@ const DownloadDialogue = ({
 
   function hasManifestRenderings(): boolean {
     return (
-      sequence.getRenderings().length > 0 || manifest.getRenderings.length > 0
+      sequence.getRenderings().length > 0 || manifest.getRenderings().length > 0
     );
   }
 


### PR DESCRIPTION
There is a bug where presentation v3 manifests fail to separate manifest-level downloads from page-level downloads. It is due to a simple typo in the code.