### PR TITLE
Fix download button styling in multiselection dialogue 

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/Config.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/Config.ts
@@ -34,7 +34,7 @@ type MultiSelectDialogueOptions = DialogueOptions & {
 };
 
 type MultiSelectDialogueContent = DialogueContent & {
-  select: string;
+  download: string;
   selectAll: string;
   title: string;
 };

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
@@ -278,7 +278,7 @@
       },
       "content": {
         "close": "$close",
-        "select": "$download",
+        "download": "$download",
         "selectAll": "$selectAll",
         "title": "$selectPagesForDownload"
       }

--- a/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/MultiSelectDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/MultiSelectDialogue.ts
@@ -74,6 +74,7 @@ export class MultiSelectDialogue extends Dialogue<
 
     this.galleryComponent = new GalleryComponent({
       target: <HTMLElement>this.$gallery[0],
+      data: this.data
     });
 
     const $downloadButton: JQuery = this.$gallery.find("a.download");

--- a/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/MultiSelectDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/MultiSelectDialogue.ts
@@ -74,7 +74,7 @@ export class MultiSelectDialogue extends Dialogue<
 
     this.galleryComponent = new GalleryComponent({
       target: <HTMLElement>this.$gallery[0],
-      data: this.data
+      data: this.data,
     });
 
     const $downloadButton: JQuery = this.$gallery.find("a.download");

--- a/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/MultiSelectDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/MultiSelectDialogue.ts
@@ -76,8 +76,8 @@ export class MultiSelectDialogue extends Dialogue<
       target: <HTMLElement>this.$gallery[0],
     });
 
-    const $selectButton: JQuery = this.$gallery.find("a.select");
-    $selectButton.addClass("btn btn-primary");
+    const $downloadButton: JQuery = this.$gallery.find("a.download");
+    $downloadButton.addClass("btn btn-primary");
 
     this.galleryComponent.on(
       "multiSelectionMade",

--- a/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/css/styles.less
@@ -18,6 +18,7 @@
                   padding-top: 6px;
                   label {
                     padding-left: 2px;
+                    padding-right: 5px;
                   }
                 }
               }

--- a/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-multiselectdialogue-module/css/styles.less
@@ -10,6 +10,7 @@
           .header {
             .btn-primary {
               width: auto;
+              color: @text-color !important;
             }
             .right {
               .multiSelectOptions {

--- a/src/content-handlers/iiif/modules/uv-shared-module/GalleryComponent.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/GalleryComponent.ts
@@ -201,8 +201,6 @@ export class GalleryComponent extends BaseComponent {
       content: <IGalleryComponentContent>{
         searchResult: "{0} search result",
         searchResults: "{0} search results",
-        download: "Download",
-        selectAll: "Select All &nbsp;",
       },
       debug: false,
       helper: null,

--- a/src/content-handlers/iiif/modules/uv-shared-module/GalleryComponent.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/GalleryComponent.ts
@@ -110,7 +110,9 @@ export class GalleryComponent extends BaseComponent {
     );
 
     this._$downloadButton = $(
-      '<a class="download" href="#">' + this.options.data.content.download + "</a>"
+      '<a class="download" href="#">' +
+        this.options.data.content.download +
+        "</a>"
     );
     this._$multiSelectOptions.append(this._$downloadButton);
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/GalleryComponent.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/GalleryComponent.ts
@@ -14,7 +14,7 @@ import { Strings, Maths } from "../../Utils";
 export interface IGalleryComponentContent {
   searchResult: string;
   searchResults: string;
-  select: string;
+  download: string;
   selectAll: string;
 }
 
@@ -47,7 +47,7 @@ export class GalleryComponent extends BaseComponent {
   private _$rightOptions: JQuery;
   private _$selectAllButton: JQuery;
   private _$selectAllButtonCheckbox: JQuery;
-  private _$selectButton: JQuery;
+  private _$downloadButton: JQuery;
   private _$selectedThumb: JQuery;
   private _$sizeDownButton: JQuery;
   private _$sizeRange: JQuery;
@@ -109,10 +109,10 @@ export class GalleryComponent extends BaseComponent {
       this._$selectAllButton.find("input:checkbox")
     );
 
-    this._$selectButton = $(
-      '<a class="select" href="#">' + this.options.data.content.select + "</a>"
+    this._$downloadButton = $(
+      '<a class="download" href="#">' + this.options.data.content.download + "</a>"
     );
-    this._$multiSelectOptions.append(this._$selectButton);
+    this._$multiSelectOptions.append(this._$downloadButton);
 
     this._$main = $('<div class="main"></div>');
     this._$element.append(this._$main);
@@ -160,7 +160,7 @@ export class GalleryComponent extends BaseComponent {
       this.set(this.options.data);
     });
 
-    this._$selectButton.on("click", () => {
+    this._$downloadButton.on("click", () => {
       const multiSelectState: MultiSelectState | null =
         this._getMultiSelectState();
 
@@ -199,8 +199,8 @@ export class GalleryComponent extends BaseComponent {
       content: <IGalleryComponentContent>{
         searchResult: "{0} search result",
         searchResults: "{0} search results",
-        select: "Select",
-        selectAll: "Select All",
+        download: "Download",
+        selectAll: "Select All &nbsp;",
       },
       debug: false,
       helper: null,
@@ -311,9 +311,9 @@ export class GalleryComponent extends BaseComponent {
         multiSelectState.getAll().filter((t) => t.multiSelected).length > 0;
 
       if (!anySelected) {
-        this._$selectButton.hide();
+        this._$downloadButton.hide();
       } else {
-        this._$selectButton.show();
+        this._$downloadButton.show();
       }
     }
   }


### PR DESCRIPTION
This PR renames the "select" button in the download selection gallery dialogue back to "download", which was the original label, for clarity. It also fixes a styling issue where that text only showed while hovering over the button. 
This requires a manifest with selectionEnabled, e.g https://gist.githubusercontent.com/Saira-A/988dcfde9afc2971c842ae0d3392a91d/raw/30a5ea0d3b7595e3cbb40f17503c3d3f21064513/gistfile1.json (no download service so the button won't actually work). 
Others have had issues getting that manifest to work so I've also included screenshots below. The "download" and "select all" labels are hard-coded in so that also needs to be fixed so will do later if needed (looks like only the BL used this feature and we might not bring it back anyway). 

<img width="919" height="538" alt="Screenshot 2026-02-20 at 16 25 27" src="https://github.com/user-attachments/assets/899cbdac-0aeb-43f8-bb93-15a891606f8e" />
<img width="917" height="539" alt="Screenshot 2026-02-20 at 16 25 34" src="https://github.com/user-attachments/assets/c0623da4-20fb-4a4f-b858-4c38681920ac" />
