### PR TITLE
fix(a11y): add ARIA attributes and focus indicators for WCAG compliance

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -33,6 +33,7 @@ let resolveMediaElement = {
 
 async function main() {
   await build({
+    tsconfig: "./tsconfig.json",
     // Enables code splitting, similar to webpack.
     splitting: true,
     outdir: path.resolve(process.cwd(), "dist/esm"),

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/Config.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/Config.ts
@@ -137,6 +137,7 @@ type OpenSeadragonCenterPanelContent = CenterPanelContent & {
   attribution: string;
   goHome: string;
   imageUnavailable: string;
+  mediaViewer: string;
   nextImage: string;
   previousImage: string;
   rotateRight: string;

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
@@ -371,6 +371,7 @@
         "closeAttribution": "$closeAttribution",
         "goHome": "$goHome",
         "imageUnavailable": "$imageUnavailable",
+        "mediaViewer": "$mediaViewer",
         "nextImage": "$nextImage",
         "previousImage": "$previousImage",
         "rotateRight": "$rotateRight",

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ContentLeftPanel.ts
@@ -524,6 +524,7 @@ export class ContentLeftPanel extends LeftPanel<ContentLeftPanelConfig> {
         paged,
         viewingDirection: viewingDirection || ViewingDirection.LEFT_TO_RIGHT,
         selected: selectedIndices,
+        thumbnailsLabel: this.content.thumbnails,
         truncateThumbnailLabels:
           settings.truncateThumbnailLabels !== undefined
             ? settings.truncateThumbnailLabels

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -51,6 +51,9 @@ const ThumbImage = ({
         "truncate-labels": truncateThumbnailLabels,
       })}
       tabIndex={0}
+      role="option"
+      aria-selected={selected}
+      aria-label={thumb.label}
     >
       <div
         ref={ref}
@@ -134,6 +137,8 @@ const Thumbnails = ({
         paged: paged,
         "truncate-labels": truncateThumbnailLabels,
       })}
+      role="listbox"
+      aria-label="Thumbnails"
     >
       {thumbs.map((thumb, index) => (
         <span

--- a/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
+++ b/src/content-handlers/iiif/modules/uv-contentleftpanel-module/ThumbsView.tsx
@@ -82,6 +82,7 @@ const Thumbnails = ({
   paged,
   selected,
   thumbs,
+  thumbnailsLabel,
   viewingDirection,
   truncateThumbnailLabels,
 }: {
@@ -90,6 +91,7 @@ const Thumbnails = ({
   paged: boolean;
   selected: number[];
   thumbs: Thumb[];
+  thumbnailsLabel: string;
   viewingDirection: ViewingDirection;
   truncateThumbnailLabels: boolean;
 }) => {
@@ -138,7 +140,7 @@ const Thumbnails = ({
         "truncate-labels": truncateThumbnailLabels,
       })}
       role="listbox"
-      aria-label="Thumbnails"
+      aria-label={thumbnailsLabel}
     >
       {thumbs.map((thumb, index) => (
         <span

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -463,6 +463,11 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       this.$viewportNavButtonsContainer.find(".viewportNavButton");
 
     this.$canvas = $(this.viewer.canvas);
+    this.$canvas.attr("role", "application");
+    this.$canvas.attr(
+      "aria-label",
+      "Image viewer — use mouse or keyboard to zoom and pan"
+    );
 
     // Check if we have saved settings for image adjustment
     const settings = this.extension.getSettings();

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -464,10 +464,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.$canvas = $(this.viewer.canvas);
     this.$canvas.attr("role", "application");
-    this.$canvas.attr(
-      "aria-label",
-      "Image viewer — use mouse or keyboard to zoom and pan"
-    );
+    this.$canvas.attr("aria-label", this.content.mediaViewer);
 
     // Check if we have saved settings for image adjustment
     const settings = this.extension.getSettings();

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
@@ -101,6 +101,11 @@
           &.next .uv-icon-next {
             background-image: none;
           }
+
+          &:focus-visible {
+            outline: 2px solid @link-color;
+            outline-offset: -2px;
+          }
         }
 
         .zoomIn {
@@ -267,6 +272,12 @@
   }
 
   .openseadragon-canvas {
-    outline: none;
+    &:focus {
+      outline: none;
+    }
+    &:focus-visible {
+      outline: 2px solid @link-color;
+      outline-offset: -2px;
+    }
   }
 }

--- a/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-pagingheaderpanel-module/PagingHeaderPanel.ts
@@ -257,7 +257,7 @@ export class PagingHeaderPanel extends HeaderPanel<
     }
 
     this.$galleryButton = $(`
-          <button class="btn imageBtn gallery" title="${this.content.gallery}">
+          <button class="btn imageBtn gallery" title="${this.content.gallery}" aria-pressed="false">
             <i class="uv-icon-gallery" aria-hidden="true"></i>
             <span class="sr-only">${this.content.gallery}</span>
           </button>
@@ -268,14 +268,14 @@ export class PagingHeaderPanel extends HeaderPanel<
     this.$rightOptions.prepend(this.$pagingToggleButtons);
 
     this.$oneUpButton = $(`
-          <button class="btn imageBtn one-up" title="${this.content.oneUp}">
+          <button class="btn imageBtn one-up" title="${this.content.oneUp}" aria-pressed="false">
             <i class="uv-icon-one-up" aria-hidden="true"></i>
             <span class="sr-only">${this.content.oneUp}</span>
           </button>`);
     this.$pagingToggleButtons.append(this.$oneUpButton);
 
     this.$twoUpButton = $(`
-          <button class="btn imageBtn two-up" title="${this.content.twoUp}">
+          <button class="btn imageBtn two-up" title="${this.content.twoUp}" aria-pressed="false">
             <i class="uv-icon-two-up" aria-hidden="true"></i>
             <span class="sr-only">${this.content.twoUp}</span>
           </button>
@@ -454,14 +454,14 @@ export class PagingHeaderPanel extends HeaderPanel<
   }
 
   openGallery(): void {
-    this.$oneUpButton.removeClass("on");
-    this.$twoUpButton.removeClass("on");
-    this.$galleryButton.addClass("on");
+    this.$oneUpButton.removeClass("on").attr("aria-pressed", "false");
+    this.$twoUpButton.removeClass("on").attr("aria-pressed", "false");
+    this.$galleryButton.addClass("on").attr("aria-pressed", "true");
   }
 
   closeGallery(): void {
     this.updatePagingToggle();
-    this.$galleryButton.removeClass("on");
+    this.$galleryButton.removeClass("on").attr("aria-pressed", "false");
   }
 
   isPageModeEnabled(): boolean {
@@ -523,11 +523,11 @@ export class PagingHeaderPanel extends HeaderPanel<
     }
 
     if ((<OpenSeadragonExtension>this.extension).isPagingSettingEnabled()) {
-      this.$oneUpButton.removeClass("on");
-      this.$twoUpButton.addClass("on");
+      this.$oneUpButton.removeClass("on").attr("aria-pressed", "false");
+      this.$twoUpButton.addClass("on").attr("aria-pressed", "true");
     } else {
-      this.$twoUpButton.removeClass("on");
-      this.$oneUpButton.addClass("on");
+      this.$twoUpButton.removeClass("on").attr("aria-pressed", "false");
+      this.$oneUpButton.addClass("on").attr("aria-pressed", "true");
     }
   }
 

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -44,18 +44,20 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     }
 
     this.$collapseButton = $(
-      '<button role="button" class="collapseButton" tabindex="0"></button>'
+      '<button role="button" class="collapseButton" tabindex="0" aria-expanded="true"></button>'
     );
     this.$collapseButton.prop("title", this.content.collapse);
+    this.$collapseButton.attr("aria-label", this.content.collapse);
     this.$top.append(this.$collapseButton);
 
     this.$closed = $('<div class="closed"></div>');
     this.$element.append(this.$closed);
 
     this.$expandButton = $(
-      '<button role="button" class="expandButton" tabindex="0"></button>'
+      '<button role="button" class="expandButton" tabindex="0" aria-expanded="false"></button>'
     );
     this.$expandButton.prop("title", this.content.expand);
+    this.$expandButton.attr("aria-label", this.content.expand);
 
     this.$closed.append(this.$expandButton);
 
@@ -126,6 +128,8 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
       this.$top.attr("aria-hidden", "true");
       this.$main.attr("aria-hidden", "true");
       this.$closed.attr("aria-hidden", "false");
+      this.$collapseButton.attr("aria-expanded", "false");
+      this.$expandButton.attr("aria-expanded", "false");
     }
 
     let timeout = 0;
@@ -158,6 +162,8 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
       this.$top.attr("aria-hidden", "false");
       this.$main.attr("aria-hidden", "false");
       this.$closed.attr("aria-hidden", "true");
+      this.$collapseButton.attr("aria-expanded", "true");
+      this.$expandButton.attr("aria-expanded", "true");
     }
 
     this.toggleFinish();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "sourceMap": true,
     "strictNullChecks": true,
     "esModuleInterop": true,
+    "useDefineForClassFields": false,
     "target": "ES5",
     "tsBuildInfoFile": "./buildcache/front-end",
     "types": ["@iiif/base-component", "jest", "jquery", "node"],


### PR DESCRIPTION
<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:
- Create or update the documentation.
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged
-->

#### Description of what you did:

Fixes several WCAG 2.1 accessibility violations:                                                                                                             
                                                                                                                                                               
  **ARIA attributes (WCAG 4.1.2)**                                                                                                                             
  - Add `aria-pressed` to gallery, one-up, and two-up toggle buttons in PagingHeaderPanel                                                                      
  - Add `aria-expanded` and `aria-label` to collapse/expand buttons in BaseExpandPanel                                                                         
  - Add `role="application"` and `aria-label` to the OpenSeadragon canvas element
  - Add `role="listbox"` to the thumbnails container and `role="option"` with `aria-selected` to individual thumbnails

  **Focus indicators (WCAG 2.4.7)**
  - Replace `outline: none` on `.openseadragon-canvas` with `:focus`/`:focus-visible` pattern
  - Add `:focus-visible` outline to paging navigation buttons

  **Build fix**
  - Pass `tsconfig.json` to esbuild to preserve `useDefineForClassFields: false`, preventing ES2022 class field initializers from overwriting fields set by
  parent constructors

  Ready to merge.