### PR TITLE
MediaElement: add type attribute to track tags.

### DIFF
--- a/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
@@ -24,6 +24,7 @@ import { Config } from "../../extensions/uv-mediaelement-extension/config/Config
 type TextTrackDescriptor = {
   language?: string;
   label?: string;
+  format?: string;
   id: string;
 };
 
@@ -174,6 +175,7 @@ export class MediaElementCenterPanel extends CenterPanel<
             label:
               rendering.getLabel().getValue() ??
               rendering.getFormat().toString(),
+            format: rendering.getFormat().toString(),
             id: rendering.id,
           });
         }
@@ -396,7 +398,7 @@ export class MediaElementCenterPanel extends CenterPanel<
       this.$media.append(
         $(`<track label="${subtitle.label}" kind="subtitles" srclang="${
           subtitle.language
-        }" src="${subtitle.id}" ${
+        }" src="${subtitle.id}" type="${subtitle.format}" ${
           subtitles.indexOf(subtitle) === 0 ? "default" : ""
         }>
 `)


### PR DESCRIPTION
While troubleshooting #1298, I thought it might be helpful to add the content type to the `<track>` tags used for subtitles. It didn't make a visible difference, but it still seems like it may be a worthwhile improvement. I've separated it to this PR so we can decide whether or not we want it.

Here is a manifest with subtitles that can be used for testing: https://digital.library.villanova.edu/Item/vudl:829943/Manifest