### PR TITLE
Fix rights label

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-aleph-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-aleph-extension/config/config.json
@@ -193,6 +193,7 @@
         "noData": "$noDataToDisplay",
         "page": "$page",
         "rangeHeader": "$aboutThisSection",
+        "rights": "$rights",
         "title": "$moreInformation"
       }
     },

--- a/src/content-handlers/iiif/extensions/uv-av-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-av-extension/config/config.json
@@ -250,6 +250,7 @@
         "moreAriaLabelTemplate": "$moreAriaLabelTemplate",
         "noData": "$noDataToDisplay",
         "page": "$page",
+        "rights": "$rights",
         "rangeHeader": "$aboutThisSection",
         "title": "$moreInformation"
       }

--- a/src/content-handlers/iiif/extensions/uv-default-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-default-extension/config/config.json
@@ -227,6 +227,7 @@
         "noData": "$noDataToDisplay",
         "page": "$page",
         "rangeHeader": "$aboutThisSection",
+        "rights": "$rights",
         "title": "$moreInformation"
       }
     },

--- a/src/content-handlers/iiif/extensions/uv-ebook-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-ebook-extension/config/config.json
@@ -189,6 +189,7 @@
         "noData": "$noDataToDisplay",
         "page": "$page",
         "rangeHeader": "$aboutThisSection",
+        "rights": "$rights",
         "title": "$moreInformation"
       }
     },

--- a/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/config.json
@@ -263,6 +263,7 @@
         "noData": "$noDataToDisplay",
         "page": "$page",
         "rangeHeader": "$aboutThisSection",
+        "rights": "$rights",
         "title": "$moreInformation"
       }
     },

--- a/src/content-handlers/iiif/extensions/uv-model-viewer-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-model-viewer-extension/config/config.json
@@ -205,6 +205,7 @@
         "noData": "$noDataToDisplay",
         "page": "$page",
         "rangeHeader": "$aboutThisSection",
+        "rights": "$rights",
         "title": "$moreInformation"
       }
     },

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/config/config.json
@@ -264,6 +264,7 @@
         "noData": "$noDataToDisplay",
         "page": "$page",
         "rangeHeader": "$aboutThisSection",
+        "rights": "$rights",
         "title": "$moreInformation"
       }
     },

--- a/src/content-handlers/iiif/extensions/uv-pdf-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-pdf-extension/config/config.json
@@ -209,6 +209,7 @@
         "noData": "$noDataToDisplay",
         "page": "$page",
         "rangeHeader": "$aboutThisSection",
+        "rights": "$rights",
         "title": "$moreInformation"
       }
     },

--- a/src/locales/cy-GB.json
+++ b/src/locales/cy-GB.json
@@ -118,6 +118,7 @@
   "$print": "Argraffu",
   "$resultFoundFor": "canlyniad a geir ar gyfer",
   "$resultsFoundFor": "canlyniad ar gyfer",
+  "$rights": "Hawliau",
   "$searchWithinItem": "Chwilio tu fewn i:",
   "$locale": "Iaith",
   "$navigatorEnabled": "Ffenest llywio ar gae",

--- a/src/locales/en-GB.json
+++ b/src/locales/en-GB.json
@@ -116,6 +116,7 @@
   "$pageLowercase": "page",
   "$previousResult": "Previous Result",
   "$print": "Print",
+  "$rights": "Rights",
   "$resultFoundFor": "result found for",
   "$resultsFoundFor": "results found for",
   "$searchWithinItem": "Search within this item:",

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -155,5 +155,6 @@
   "$duration": "Durée",
   "$mute": "Muet",
   "$pause": "Pause",
-  "$play": "Jouer"
+  "$play": "Jouer",
+  "$rights": "Droits"
 }

--- a/src/locales/pl-PL.json
+++ b/src/locales/pl-PL.json
@@ -155,5 +155,6 @@
   "$duration": "Czas trwania",
   "$mute": "Wycisz",
   "$pause": "Pauza",
-  "$play": "Odtwarzaj"
+  "$play": "Odtwarzaj",
+  "$rights": "Prawa"
 }

--- a/src/locales/sv-SE.json
+++ b/src/locales/sv-SE.json
@@ -160,5 +160,6 @@
   "$contrast": "Kontrast",
   "$saturation": "Färgmättnad",
   "$reset": "Återställ",
-  "$remember": "Kom ihåg mina inställningar"
+  "$remember": "Kom ihåg mina inställningar",
+  "$rights": "Rättigheter"
 }


### PR DESCRIPTION
This supplies the default content string for the `rights` property in Presentation v3 manifests, which appears in the metadata component. Currently the metadata component shows an empty string for manifests with the `rights` metadata label, e.g.:

https://www.universalviewer.dev/#?xywh=-340%2C-335%2C4710%2C3692&iiifManifestId=https%3A%2F%2Fiiif.io%2Fapi%2Fcookbook%2Frecipe%2F0008-rights%2Fmanifest.json

Waiting for French, Swedish, Polish, Welsh translations so I'll leave this in draft. 