### PR TITLE
Fix no download available message

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -306,10 +306,6 @@ const DownloadDialogue = ({
         return false;
       case DownloadOption.ENTIRE_FILE_AS_ORIGINAL:
         return mediaDownloadEnabled;
-
-      // JM temporarily test manifest renderings
-      case DownloadOption.MANIFEST_RENDERINGS:
-        return true;
       default:
         return true;
     }

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -284,6 +284,7 @@ const DownloadDialogue = ({
             return false;
           }
         }
+
         return true;
       case DownloadOption.WHOLE_IMAGE_LOW_RES:
         if (!downloadWholeImageLowResEnabled) {
@@ -527,6 +528,13 @@ const DownloadDialogue = ({
   //   return resource.getRenderings().length > 0;
   // }
 
+  function hasRangeRenderings(): boolean {
+    const canvas: Canvas = getSelectedCanvas();
+    return (canvas.ranges ?? []).some(
+      (range: Range) => range.getRenderings().length > 0
+    );
+  }
+
   function RangeRenderings() {
     const canvas: Canvas = getSelectedCanvas();
 
@@ -541,6 +549,15 @@ const DownloadDialogue = ({
           />
         ))}
       </>
+    );
+  }
+
+  function hasImageRenderings() {
+    const canvas: Canvas = getSelectedCanvas();
+    const images: Annotation[] = canvas.getImages();
+
+    return images.some(
+      (image: Annotation) => image.getResource().getRenderings().length > 0
     );
   }
 
@@ -560,6 +577,11 @@ const DownloadDialogue = ({
         ))}
       </>
     );
+  }
+
+  function hasCanvasRenderings() {
+    const canvas: Canvas = getSelectedCanvas();
+    return canvas.getRenderings().length > 0;
   }
 
   function CanvasRenderings() {
@@ -667,15 +689,24 @@ const DownloadDialogue = ({
     );
   }
 
-  if (isDownloadOptionAvailable(DownloadOption.RANGE_RENDERINGS)) {
+  if (
+    isDownloadOptionAvailable(DownloadOption.RANGE_RENDERINGS) &&
+    hasRangeRenderings()
+  ) {
     individualPageOptions.push(<RangeRenderings key="range-renderings" />);
   }
 
-  if (isDownloadOptionAvailable(DownloadOption.IMAGE_RENDERINGS)) {
+  if (
+    isDownloadOptionAvailable(DownloadOption.IMAGE_RENDERINGS) &&
+    hasImageRenderings()
+  ) {
     individualPageOptions.push(<ImageRenderings key="image-renderings" />);
   }
 
-  if (isDownloadOptionAvailable(DownloadOption.CANVAS_RENDERINGS)) {
+  if (
+    isDownloadOptionAvailable(DownloadOption.CANVAS_RENDERINGS) &&
+    hasCanvasRenderings()
+  ) {
     individualPageOptions.push(<CanvasRenderings key="canvas-renderings" />);
   }
 

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -609,18 +609,99 @@ const DownloadDialogue = ({
     ) : null;
   }
 
-  const hasIndividualPageOptions =
-    isDownloadOptionAvailable(DownloadOption.CURRENT_VIEW) ||
-    isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_HIGH_RES) ||
-    isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_LOW_RES) ||
-    isDownloadOptionAvailable(DownloadOption.RANGE_RENDERINGS) ||
-    isDownloadOptionAvailable(DownloadOption.IMAGE_RENDERINGS) ||
-    isDownloadOptionAvailable(DownloadOption.CANVAS_RENDERINGS);
+  const individualPageOptions: React.ReactNode[] = [];
 
-  const hasAllPageOptions =
-    (hasManifestRenderings() &&
-      isDownloadOptionAvailable(DownloadOption.MANIFEST_RENDERINGS)) ||
-    isDownloadOptionAvailable(DownloadOption.SELECTION);
+  if (isDownloadOptionAvailable(DownloadOption.CURRENT_VIEW)) {
+    individualPageOptions.push(
+      <li key="current-view" className="option single">
+        <button onClick={() => { onDownload(DownloadOption.CURRENT_VIEW, getCurrentViewLabel()); onDownloadCurrentView(getSelectedCanvas()); }}>
+          {getCurrentViewLabel()}
+        </button>
+      </li>
+    );
+  }
+
+  if (isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_HIGH_RES)) {
+    individualPageOptions.push(
+      <li key="high-res" className="option single">
+        <button
+          onClick={() => {
+            onDownload(
+              DownloadOption.WHOLE_IMAGES_HIGH_RES,
+              getWholeImageHighResLabel()
+            );
+            window.open(getCanvasHighResImageUri(getSelectedCanvas()));
+          }}
+        >
+          {getWholeImageHighResLabel()}
+        </button>
+      </li>
+    );
+  }
+
+  if (isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_LOW_RES)) {
+    individualPageOptions.push(
+      <li key="low-res" className="option single">
+        <button
+          onClick={() => {
+            onDownload(
+              DownloadOption.WHOLE_IMAGE_LOW_RES,
+              getWholeImageLowResLabel()
+            );
+            const imageUri: string | null =
+              getConfinedImageUri(getSelectedCanvas());
+
+            if (imageUri) {
+              window.open(imageUri);
+            }
+          }}
+        >
+          {getWholeImageLowResLabel()}
+        </button>
+      </li>
+    );
+  }
+
+  if (isDownloadOptionAvailable(DownloadOption.RANGE_RENDERINGS)) {
+    individualPageOptions.push(
+      <RangeRenderings key="range-renderings"/>
+    );
+  }
+
+  if (isDownloadOptionAvailable(DownloadOption.IMAGE_RENDERINGS)) {
+    individualPageOptions.push(
+      <ImageRenderings key="image-renderings"/>
+    );
+  }
+
+  if (isDownloadOptionAvailable(DownloadOption.CANVAS_RENDERINGS)) {
+    individualPageOptions.push(
+      <CanvasRenderings key="canvas-renderings"/>
+    );
+  }
+
+  const allPageOptions: React.ReactNode[] = [];
+
+  if (isDownloadOptionAvailable(DownloadOption.MANIFEST_RENDERINGS) && hasManifestRenderings()) {
+    allPageOptions.push(
+      <ManifestRenderings key="manifest-renderings"/>
+    );
+  }
+
+  if (isDownloadOptionAvailable(DownloadOption.SELECTION)) {
+    allPageOptions.push(
+      <li key="selection" className="option single">
+        <button
+          onClick={() => {
+            onDownload(DownloadOption.SELECTION, content.selection);
+            onDownloadSelection();
+          }}
+        >
+          {content.selection}
+        </button>
+      </li>
+    );
+  }
 
   return (
     <div ref={ref} className={cx("overlay download")} style={position}>
@@ -631,12 +712,12 @@ const DownloadDialogue = ({
             {content.download}
           </div>
 
-          {!hasIndividualPageOptions && !hasAllPageOptions && (
+          {!individualPageOptions.length && !allPageOptions.length && (
             <p>{content.noneAvailable}</p>
           )}
 
           {/* if in two-up, show two pages next to each other to choose from */}
-          {hasIndividualPageOptions && <h2>{content.individualPages}</h2>}
+          {individualPageOptions.length > 0 && <h2>{content.individualPages}</h2>}
           {canvases.length === 2 && (
             <div className="pages">
               <div
@@ -665,87 +746,11 @@ const DownloadDialogue = ({
               </div>
             </div>
           )}
-          <ol className="options">
-            {isDownloadOptionAvailable(DownloadOption.CURRENT_VIEW) && (
-              <li className="option single">
-                <button
-                  onClick={() => {
-                    onDownload(
-                      DownloadOption.CURRENT_VIEW,
-                      getCurrentViewLabel()
-                    );
-                    onDownloadCurrentView(getSelectedCanvas());
-                  }}
-                >
-                  {getCurrentViewLabel()}
-                </button>
-              </li>
-            )}
-            {isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_HIGH_RES) && (
-              <li className="option single">
-                <button
-                  onClick={() => {
-                    onDownload(
-                      DownloadOption.WHOLE_IMAGES_HIGH_RES,
-                      getWholeImageHighResLabel()
-                    );
-                    window.open(getCanvasHighResImageUri(getSelectedCanvas()));
-                  }}
-                >
-                  {getWholeImageHighResLabel()}
-                </button>
-              </li>
-            )}
-            {isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_LOW_RES) && (
-              <li className="option single">
-                <button
-                  onClick={() => {
-                    onDownload(
-                      DownloadOption.WHOLE_IMAGE_LOW_RES,
-                      getWholeImageLowResLabel()
-                    );
-                    const imageUri: string | null =
-                      getConfinedImageUri(getSelectedCanvas());
+          <ol className="options">{individualPageOptions}</ol>
 
-                    if (imageUri) {
-                      window.open(imageUri);
-                    }
-                  }}
-                >
-                  {getWholeImageLowResLabel()}
-                </button>
-              </li>
-            )}
-            {isDownloadOptionAvailable(DownloadOption.RANGE_RENDERINGS) && (
-              <RangeRenderings />
-            )}
-            {isDownloadOptionAvailable(DownloadOption.IMAGE_RENDERINGS) && (
-              <ImageRenderings />
-            )}
-            {isDownloadOptionAvailable(DownloadOption.CANVAS_RENDERINGS) && (
-              <CanvasRenderings />
-            )}
-          </ol>
+          {allPageOptions.length > 0 && <h2>{content.allPages}</h2>}
+          <ol className="options">{allPageOptions}</ol>
 
-          {hasAllPageOptions && <h2>{content.allPages}</h2>}
-
-          <ol className="options">
-            {isDownloadOptionAvailable(DownloadOption.MANIFEST_RENDERINGS) && (
-              <ManifestRenderings />
-            )}
-            {isDownloadOptionAvailable(DownloadOption.SELECTION) && (
-              <li className="option single">
-                <button
-                  onClick={() => {
-                    onDownload(DownloadOption.SELECTION, content.selection);
-                    onDownloadSelection();
-                  }}
-                >
-                  {content.selection}
-                </button>
-              </li>
-            )}
-          </ol>
           <div className="footer">
             <TermsOfUse />
           </div>

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -230,7 +230,6 @@ const DownloadDialogue = ({
         return resources[0];
       }
     }
-
     return null;
   }
 
@@ -250,7 +249,10 @@ const DownloadDialogue = ({
       !canvas.externalResource.hasServiceDescriptor() ||
       isLevel0(canvas.externalResource.data.profile)
     ) {
-      if (option === DownloadOption.WHOLE_IMAGE_HIGH_RES) {
+      if (
+        option === DownloadOption.WHOLE_IMAGE_HIGH_RES &&
+        downloadWholeImageHighResEnabled
+      ) {
         // if in one-up mode, or in two-up mode with a single page being shown
         if (!(paged || (paged && selectedResource))) {
           return true;
@@ -304,6 +306,10 @@ const DownloadDialogue = ({
         return false;
       case DownloadOption.ENTIRE_FILE_AS_ORIGINAL:
         return mediaDownloadEnabled;
+
+      // JM temporarily test manifest renderings
+      case DownloadOption.MANIFEST_RENDERINGS:
+        return true;
       default:
         return true;
     }
@@ -607,6 +613,19 @@ const DownloadDialogue = ({
     ) : null;
   }
 
+  const hasIndividualPageOptions =
+    isDownloadOptionAvailable(DownloadOption.CURRENT_VIEW) ||
+    isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_HIGH_RES) ||
+    isDownloadOptionAvailable(DownloadOption.WHOLE_IMAGE_LOW_RES) ||
+    isDownloadOptionAvailable(DownloadOption.RANGE_RENDERINGS) ||
+    isDownloadOptionAvailable(DownloadOption.IMAGE_RENDERINGS) ||
+    isDownloadOptionAvailable(DownloadOption.CANVAS_RENDERINGS);
+
+  const hasAllPageOptions =
+    (hasManifestRenderings() &&
+      isDownloadOptionAvailable(DownloadOption.MANIFEST_RENDERINGS)) ||
+    isDownloadOptionAvailable(DownloadOption.SELECTION);
+
   return (
     <div ref={ref} className={cx("overlay download")} style={position}>
       <div className="top"></div>
@@ -615,9 +634,13 @@ const DownloadDialogue = ({
           <div role="heading" className="heading">
             {content.download}
           </div>
-          {/* <div className="nonAvailable">No download options are available</div> */}
+
+          {!hasIndividualPageOptions && !hasAllPageOptions && (
+            <p>{content.noneAvailable}</p>
+          )}
+
           {/* if in two-up, show two pages next to each other to choose from */}
-          <h2>{content.individualPages}</h2>
+          {hasIndividualPageOptions && <h2>{content.individualPages}</h2>}
           {canvases.length === 2 && (
             <div className="pages">
               <div
@@ -707,10 +730,9 @@ const DownloadDialogue = ({
               <CanvasRenderings />
             )}
           </ol>
-          {(hasManifestRenderings() ||
-            isDownloadOptionAvailable(DownloadOption.SELECTION)) && (
-            <h2>{content.allPages}</h2>
-          )}
+
+          {hasAllPageOptions && <h2>{content.allPages}</h2>}
+
           <ol className="options">
             {isDownloadOptionAvailable(DownloadOption.MANIFEST_RENDERINGS) && (
               <ManifestRenderings />

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -614,7 +614,12 @@ const DownloadDialogue = ({
   if (isDownloadOptionAvailable(DownloadOption.CURRENT_VIEW)) {
     individualPageOptions.push(
       <li key="current-view" className="option single">
-        <button onClick={() => { onDownload(DownloadOption.CURRENT_VIEW, getCurrentViewLabel()); onDownloadCurrentView(getSelectedCanvas()); }}>
+        <button
+          onClick={() => {
+            onDownload(DownloadOption.CURRENT_VIEW, getCurrentViewLabel());
+            onDownloadCurrentView(getSelectedCanvas());
+          }}
+        >
           {getCurrentViewLabel()}
         </button>
       </li>
@@ -663,29 +668,24 @@ const DownloadDialogue = ({
   }
 
   if (isDownloadOptionAvailable(DownloadOption.RANGE_RENDERINGS)) {
-    individualPageOptions.push(
-      <RangeRenderings key="range-renderings"/>
-    );
+    individualPageOptions.push(<RangeRenderings key="range-renderings" />);
   }
 
   if (isDownloadOptionAvailable(DownloadOption.IMAGE_RENDERINGS)) {
-    individualPageOptions.push(
-      <ImageRenderings key="image-renderings"/>
-    );
+    individualPageOptions.push(<ImageRenderings key="image-renderings" />);
   }
 
   if (isDownloadOptionAvailable(DownloadOption.CANVAS_RENDERINGS)) {
-    individualPageOptions.push(
-      <CanvasRenderings key="canvas-renderings"/>
-    );
+    individualPageOptions.push(<CanvasRenderings key="canvas-renderings" />);
   }
 
   const allPageOptions: React.ReactNode[] = [];
 
-  if (isDownloadOptionAvailable(DownloadOption.MANIFEST_RENDERINGS) && hasManifestRenderings()) {
-    allPageOptions.push(
-      <ManifestRenderings key="manifest-renderings"/>
-    );
+  if (
+    isDownloadOptionAvailable(DownloadOption.MANIFEST_RENDERINGS) &&
+    hasManifestRenderings()
+  ) {
+    allPageOptions.push(<ManifestRenderings key="manifest-renderings" />);
   }
 
   if (isDownloadOptionAvailable(DownloadOption.SELECTION)) {
@@ -717,7 +717,9 @@ const DownloadDialogue = ({
           )}
 
           {/* if in two-up, show two pages next to each other to choose from */}
-          {individualPageOptions.length > 0 && <h2>{content.individualPages}</h2>}
+          {individualPageOptions.length > 0 && (
+            <h2>{content.individualPages}</h2>
+          )}
           {canvases.length === 2 && (
             <div className="pages">
               <div


### PR DESCRIPTION
This addresses https://github.com/UniversalViewer/universalviewer/issues/1642 by properly displaying the 'no download available' message, and removing the headings from empty sections in the download dialogue. 

The test manifest on issue 1642 was confusing things by bringing an auth issue into the mix. But this PR can be tested with other manifests without `rendering` (e.g. https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json) and by setting the config in the configuration builder to

`{
  "modules": {
    "downloadDialogue": {
      "options": {
        "downloadCurrentViewEnabled": false,
        "downloadWholeImageHighResEnabled": false,
        "downloadWholeImageLowResEnabled": false
      }
    }
  }
}`

This is hopefully an incremental improvement but there are lots of outstanding issues within the download dialogue! E.g. the full range of download options listed in the downloadOptions enum aren't being checked for yet. I haven't had time to fully understand the various download options that are surfaced in a manifest, but I imagine we also want an option to download the seeAlso if it's a transcription file.