### PR TITLE
Update manifesto to v4.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11153,9 +11153,9 @@
       }
     },
     "node_modules/manifesto.js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.3.0.tgz",
-      "integrity": "sha512-UhnJ/m4KrbVUrqjlJvURakAR68y3twBXecocRiWU8MIvDJdwA1clYTtHz+in0LeYIgb6yuLZ7vStQ7ixtkkEAw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/manifesto.js/-/manifesto.js-4.3.2.tgz",
+      "integrity": "sha512-q13F4F3t4ss+9JBW/Xr68Tm/p1Cdj9NIC74D8y9In3/ieIQKkIQFFDrsFWDVAAEhVs32QJ1wzjU+KuAIVHAcJg==",
       "license": "MIT",
       "dependencies": {
         "@edsilv/http-status-codes": "^1.0.3",


### PR DESCRIPTION
This updates to the new patch of manifesto which updated the handling of maxWidth values on the info.json:

https://github.com/IIIF-Commons/manifesto/pull/170

This addresses https://github.com/UniversalViewer/universalviewer/issues/1706

It can be tested with the manifests on the Digirati staging server supplied to the BL IIIF team.

NB the expected behavior in the issue states that the links should not appear; the links still appear, but they are to a lower download size (which is better!)