### PR TITLE
Prevent the OSD canvas focus outline from appearing on initial mouse interaction

### DIFF
--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -579,6 +579,26 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
     this.isCreated = true;
     //this.resize();
+
+    // check if initial interaction is keyboard navigation or mouse
+    // this prevents blue focus border from appearing on first mouse interaction
+    document.addEventListener(
+      "keydown",
+      (e: KeyboardEvent) => {
+        if (e.key === "Tab") {
+          this.$canvas?.addClass("keyboard-nav");
+        }
+      },
+      { capture: true }
+    );
+
+    document.addEventListener(
+      "pointerdown",
+      () => {
+        this.$canvas?.removeClass("keyboard-nav");
+      },
+      { capture: true }
+    );
   }
 
   createNavigationButtons() {

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
@@ -275,7 +275,7 @@
     &:focus {
       outline: none;
     }
-    &:focus-visible {
+    &.keyboard-nav:focus-visible {
       outline: 2px solid @link-color;
       outline-offset: -2px;
     }


### PR DESCRIPTION
This fixes https://github.com/UniversalViewer/universalviewer/issues/1709

It adds event listeners to check whether the last interaction was the tab key or the mouse, and adds a class to the OSD canvas, which is then used to conditionally style the blue focus outline.

We might want to consider adding more than just the Tab key to the keys that trigger the 'keyboard-nav' class but I think this covers the basics.