### PR TITLE
Fix unwanted auto focus of expand panel UI

### DIFF
--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -274,7 +274,7 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     return 0;
   }
 
-  toggleStart(): void { }
+  toggleStart(): void {}
 
   toggleFinish(): void {
     if (this.autoToggled) {
@@ -288,14 +288,14 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     }
   }
 
-  expandFullStart(): void { }
+  expandFullStart(): void {}
 
   expandFullFinish(): void {
     this.isFullyExpanded = true;
     this.$expandFullButton.hide();
   }
 
-  collapseFullStart(): void { }
+  collapseFullStart(): void {}
 
   collapseFullFinish(): void {
     this.isFullyExpanded = false;

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -274,34 +274,28 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     return 0;
   }
 
-  toggleStart(): void {}
+  toggleStart(): void { }
 
   toggleFinish(): void {
-    // if panel was auto toggled and we don't allow steal focus,
-    // don't focus anything to prevent unexpected behaviour
-    // e.g. browser jumping page to the focused element
-    if (
-      this.autoToggled &&
-      !this.extension.data.config!.options.allowStealFocus
-    ) {
+    if (this.autoToggled) {
       return;
     }
 
-    if (this.isExpanded && !this.autoToggled) {
+    if (this.isExpanded) {
       this.focusCollapseButton();
     } else {
       this.focusExpandButton();
     }
   }
 
-  expandFullStart(): void {}
+  expandFullStart(): void { }
 
   expandFullFinish(): void {
     this.isFullyExpanded = true;
     this.$expandFullButton.hide();
   }
 
-  collapseFullStart(): void {}
+  collapseFullStart(): void { }
 
   collapseFullFinish(): void {
     this.isFullyExpanded = false;

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -274,10 +274,10 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     return 0;
   }
 
-  toggleStart(): void { }
+  toggleStart(): void {}
 
   toggleFinish(): void {
-    // if panel was auto toggled and we don't allow steal focus, 
+    // if panel was auto toggled and we don't allow steal focus,
     // don't focus anything to prevent unexpected behaviour
     // e.g. browser jumping page to the focused element
     if (
@@ -294,14 +294,14 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     }
   }
 
-  expandFullStart(): void { }
+  expandFullStart(): void {}
 
   expandFullFinish(): void {
     this.isFullyExpanded = true;
     this.$expandFullButton.hide();
   }
 
-  collapseFullStart(): void { }
+  collapseFullStart(): void {}
 
   collapseFullFinish(): void {
     this.isFullyExpanded = false;

--- a/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-shared-module/BaseExpandPanel.ts
@@ -274,9 +274,19 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     return 0;
   }
 
-  toggleStart(): void {}
+  toggleStart(): void { }
 
   toggleFinish(): void {
+    // if panel was auto toggled and we don't allow steal focus, 
+    // don't focus anything to prevent unexpected behaviour
+    // e.g. browser jumping page to the focused element
+    if (
+      this.autoToggled &&
+      !this.extension.data.config!.options.allowStealFocus
+    ) {
+      return;
+    }
+
     if (this.isExpanded && !this.autoToggled) {
       this.focusCollapseButton();
     } else {
@@ -284,14 +294,14 @@ export class BaseExpandPanel<T extends ExpandPanel> extends BaseView<T> {
     }
   }
 
-  expandFullStart(): void {}
+  expandFullStart(): void { }
 
   expandFullFinish(): void {
     this.isFullyExpanded = true;
     this.$expandFullButton.hide();
   }
 
-  collapseFullStart(): void {}
+  collapseFullStart(): void { }
 
   collapseFullFinish(): void {
     this.isFullyExpanded = false;


### PR DESCRIPTION
Fixes #1720 

I realised that the else condition was firing incorrectly so I've moved the autoToggled check to be a guard and this fixes the issue on my test page.

Now when a panel is auto opened it won't cause a focus to its expand/collapse ui.

Let me know if you need some test html to verify it working.