### PR TITLE
Disable keyboard focus on disabled next/prev buttons.

### DIFF
--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -1106,11 +1106,13 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
   disablePrevButton(): void {
     this.prevButtonEnabled = false;
     this.$prevButton.addClass("disabled");
+    this.$prevButton.attr("tabindex", -1);
   }
 
   enablePrevButton(): void {
     this.prevButtonEnabled = true;
     this.$prevButton.removeClass("disabled");
+    this.$prevButton.attr("tabindex", 0);
   }
 
   hidePrevButton(): void {
@@ -1126,11 +1128,13 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
   disableNextButton(): void {
     this.nextButtonEnabled = false;
     this.$nextButton.addClass("disabled");
+    this.$nextButton.attr("tabindex", -1);
   }
 
   enableNextButton(): void {
     this.nextButtonEnabled = true;
     this.$nextButton.removeClass("disabled");
+    this.$nextButton.attr("tabindex", 0);
   }
 
   hideNextButton(): void {


### PR DESCRIPTION
When using the Tab key to move through the UV UI, disabled next/prev buttons would receive focus even though they do not function. This PR corrects the bad behavior.