### PR TITLE
Fix extra outlines in next/prev buttons.

### DIFF
--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
@@ -105,8 +105,9 @@
           &:focus-visible {
             outline: 2px solid @link-color;
             outline-offset: -2px;
-            i, span {
-              outline: 0px;
+            i,
+            span {
+              outline: 0;
             }
           }
         }

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/css/styles.less
@@ -105,6 +105,9 @@
           &:focus-visible {
             outline: 2px solid @link-color;
             outline-offset: -2px;
+            i, span {
+              outline: 0px;
+            }
           }
         }
 


### PR DESCRIPTION
This fixes a display glitch on the focused next/prev buttons.

Before fix:

<img width="42" height="105" alt="image" src="https://github.com/user-attachments/assets/b0480252-a3b3-42be-bd8b-0b92c17f43fb" />

After fix:

<img width="38" height="104" alt="image" src="https://github.com/user-attachments/assets/f8fdf532-c935-41ac-9363-f415ed090d43" />
