### PR TITLE
Fix hidden search results

### DIFF
--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/css/styles.less
@@ -117,7 +117,7 @@
           padding: 0;
           max-height: 300px;
           overflow: hidden auto;
-          z-index: 15;
+          z-index: 25;
 
           .result {
             padding: 4px;

--- a/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/css/styles.less
+++ b/src/content-handlers/iiif/modules/uv-searchfooterpanel-module/css/styles.less
@@ -117,6 +117,7 @@
           padding: 0;
           max-height: 300px;
           overflow: hidden auto;
+          z-index: 15;
 
           .result {
             padding: 4px;


### PR DESCRIPTION
This fixes the issue found in #1726 where search results hide underneath the image by adding a z-index to the autocomplete function 