### PR TITLE
Route m3u8 files to AV

### DIFF
--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -142,7 +142,9 @@ export default class IIIFContentHandler
     this._extensionRegistry[MediaType.GLB] = Extension.MODELVIEWER;
     this._extensionRegistry[MediaType.GLTF] = Extension.MODELVIEWER;
     this._extensionRegistry[MediaType.JPG] = Extension.OSD;
+    this._extensionRegistry[MediaType.M3U8] = Extension.AV;
     this._extensionRegistry[MediaType.MP3] = Extension.AV;
+    this._extensionRegistry[MediaType.MPD] = Extension.AV;
     this._extensionRegistry[MediaType.MPEG] = Extension.AV;
     this._extensionRegistry[MediaType.MPEG_DASH] = Extension.AV;
     this._extensionRegistry[MediaType.OPF] = Extension.EBOOK;

--- a/src/content-handlers/iiif/IIIFContentHandler.ts
+++ b/src/content-handlers/iiif/IIIFContentHandler.ts
@@ -144,7 +144,6 @@ export default class IIIFContentHandler
     this._extensionRegistry[MediaType.JPG] = Extension.OSD;
     this._extensionRegistry[MediaType.M3U8] = Extension.AV;
     this._extensionRegistry[MediaType.MP3] = Extension.AV;
-    this._extensionRegistry[MediaType.MPD] = Extension.AV;
     this._extensionRegistry[MediaType.MPEG] = Extension.AV;
     this._extensionRegistry[MediaType.MPEG_DASH] = Extension.AV;
     this._extensionRegistry[MediaType.OPF] = Extension.EBOOK;


### PR DESCRIPTION
This adds support for AV manifests using m3u8 (HLS), such as [this](https://gist.githubusercontent.com/Saira-A/15f6328dc7b2a539105ea743a807d2db/raw/4202fafb941e3eaaf7cba0f43d6d129c18c6ba0c/video-4x3.json).
