### PR TITLE
MediaElementCenterPanel: make iconSprite configurable.

### DIFF
--- a/manual/CONFIG.md
+++ b/manual/CONFIG.md
@@ -1118,6 +1118,12 @@ Specifies the default height for the panel or content.
 **Default**: `560`  
 Specifies the default width for the panel or content.
 
+##### iconSprite
+
+**Type**: `string`  
+**Default**: `mejs-controls.svg`  
+Specifies the URL of the spritesheet used by MediaElement.
+
 ##### titleEnabled
 
 **Type**: `boolean`  

--- a/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/Config.ts
+++ b/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/Config.ts
@@ -15,7 +15,7 @@ type MediaElementCenterPanelOptions = CenterPanelOptions & {
   autoPlayOnSetTarget: boolean;
   defaultHeight: number;
   defaultWidth: number;
-  iconSprite?: string;
+  iconSprite: string;
 };
 
 type MediaElementCenterPanelContent = CenterPanelContent & {};

--- a/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/Config.ts
+++ b/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/Config.ts
@@ -15,6 +15,7 @@ type MediaElementCenterPanelOptions = CenterPanelOptions & {
   autoPlayOnSetTarget: boolean;
   defaultHeight: number;
   defaultWidth: number;
+  iconSprite?: string;
 };
 
 type MediaElementCenterPanelContent = CenterPanelContent & {};

--- a/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/config.json
+++ b/src/content-handlers/iiif/extensions/uv-mediaelement-extension/config/config.json
@@ -169,6 +169,7 @@
         "autoPlayOnSetTarget": false,
         "defaultHeight": 420,
         "defaultWidth": 560,
+        "iconSprite": "mejs-controls.svg",
         "titleEnabled": true,
         "subtitleEnabled": true,
         "mostSpecificRequiredStatement": true,

--- a/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-mediaelementcenterpanel-module/MediaElementCenterPanel.ts
@@ -223,6 +223,7 @@ export class MediaElementCenterPanel extends CenterPanel<
       this.$container.append(this.$media);
 
       this.player = new MediaElementPlayer($("video")[0], {
+        iconSprite: this.config.options.iconSprite,
         poster: poster,
         toggleCaptionsButtonWhenOnlyOne: true,
         features: [


### PR DESCRIPTION
This PR makes the MediaElement iconSprite setting configurable -- this makes it easier to integrate static assets in ESM-based platforms like Vite.