### PR TITLE
4.4.0 rc3 bug fix

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/ChoiceSwitchDialogue.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/ChoiceSwitchDialogue.ts
@@ -86,6 +86,7 @@ export class ChoiceSwitchDialogue extends BaseChoiceSwitchDialogue {
     });
 
     const mobileFooterButton = extension.mobileFooterPanel?.$choiceSwitchButton;
+
     this.$anchor =
       mobileFooterButton?.is(":visible") && mobileFooterButton?.length
         ? mobileFooterButton

--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/Extension.ts
@@ -620,16 +620,14 @@ export default class OpenSeadragonExtension extends BaseExtension<Config> {
       this.footerPanel.init();
     }
 
-    if (this.helper.hasChoices()) {
-      this.$choiceSwitchDialogue = $(
-        '<div class="overlay choiceSwitch" aria-hidden="true"></div>'
-      );
-      this.shell.$overlays.append(this.$choiceSwitchDialogue);
-      this.choiceSwitchDialogue = new ChoiceSwitchDialogue(
-        this.$choiceSwitchDialogue,
-        this.shell
-      );
-    }
+    this.$choiceSwitchDialogue = $(
+      '<div class="overlay choiceSwitch" aria-hidden="true"></div>'
+    );
+    this.shell.$overlays.append(this.$choiceSwitchDialogue);
+    this.choiceSwitchDialogue = new ChoiceSwitchDialogue(
+      this.$choiceSwitchDialogue,
+      this.shell
+    );
   }
 
   render(): void {

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -636,6 +636,8 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     this.hidePrevButton();
     this.hideNextButton();
 
+    this.createChoiceSwitch();
+
     this.isCreated = true;
     //this.resize();
 
@@ -658,8 +660,6 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       },
       { capture: true }
     );
-
-    this.createChoiceSwitch();
 
     this.extensionHost.subscribe(IIIFEvents.CLOSE_ACTIVE_DIALOGUE, () => {
       this.$viewer.removeClass("dialogue-open");
@@ -773,12 +773,6 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
   }
 
   createChoiceSwitch(): void {
-    // check for a choice on either of the displayed canvases if in 2-up view
-    const indices = this.extension.getPagedIndices();
-    const hasChoices = this.indicesIncludeChoices(indices);
-
-    if (!hasChoices) return;
-
     this.$choiceSwitchButton = this.$rotateButton.clone();
     this.$choiceSwitchButton.attr("title", this.content.layers);
     this.$choiceSwitchButton.attr("aria-label", this.content.layers);
@@ -791,6 +785,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       this.$choiceSwitchButton.insertAfter(this.$rotateButton);
     }
     this.onAccessibleClick(this.$choiceSwitchButton, () => {
+      console.log("choice clicked");
       this.extensionHost.publish(IIIFEvents.SHOW_CHOICE_SWITCH_DIALOGUE);
     });
   }

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -774,8 +774,8 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
 
   createChoiceSwitch(): void {
     this.$choiceSwitchButton = this.$rotateButton.clone();
-    this.$choiceSwitchButton.attr("title", this.content.layers);
     this.$choiceSwitchButton.attr("aria-label", this.content.layers);
+    this.$choiceSwitchButton.attr("title", this.content.layers);
     this.$choiceSwitchButton.switchClass("rotate", "choiceSwitch");
     this.$choiceSwitchButton.attr("tabindex", 0);
 

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -785,7 +785,6 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
       this.$choiceSwitchButton.insertAfter(this.$rotateButton);
     }
     this.onAccessibleClick(this.$choiceSwitchButton, () => {
-      console.log("choice clicked");
       this.extensionHost.publish(IIIFEvents.SHOW_CHOICE_SWITCH_DIALOGUE);
     });
   }


### PR DESCRIPTION
release-4.4.0-rc2 had a bug where the rendering of the choice button was out of sync with the loading of the manifest. In certain conditions, the manifest hadn't loaded before the UI was created, so it wasn't aware of the choice.

This cleans up some of the redundant condition checks that were causing this - one on the extension, and the other in `createChoiceSwitch` in the OpenseaDragonCenterPanel. Now, the only time that the presence of choice is checked, is in `openPagesHandler`, after the page has loaded, which makes the button visible or invisible. This is more in line with how other UI elements are rendered anyway.

(re-opened from https://github.com/jamesmisson/universalviewer/pull/3 which was targeted to the wrong branch. The edit in line 778 is just to enable a new PR)