### PR TITLE
Modify rotation to prevent download errors

### DIFF
--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -240,7 +240,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
     const current = this.viewer.viewport.getRotation();
     const next = (current + 90) % 360;
     this.viewer.viewport.setRotation(next);
-}
+  }
 
   updateResponsiveView(): void {
     this.setNavigatorVisible();

--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -237,8 +237,10 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
   }
 
   rotateRight(): void {
-    this.viewer.viewport.setRotation(this.viewer.viewport.getRotation() + 90);
-  }
+    const current = this.viewer.viewport.getRotation();
+    const next = (current + 90) % 360;
+    this.viewer.viewport.setRotation(next);
+}
 
   updateResponsiveView(): void {
     this.setNavigatorVisible();


### PR DESCRIPTION
Currently, if an image is rotated right four times so it's back at it's original orientation, the URL generated when download is requested will contain a rotation value of 360 rather than zero. Though 360 and 0 are visually the same, IIIF image servers tend to throw errors at 360, e.g: 
https://bl.digirati.io/images/ark:/81055/man_10000049.0x000018/full/1553,/360/default.jpg
https://iiif.wellcomecollection.org/image/b18035723_0001.JP2/full/2569,/360/default.jpg
https://iiif.library.villanova.edu/image/vudl%3A92894/full/691,1000/360/default.jpg 

The same URLs work if 360 is replaced with 0. This PR uses modulo 360 so that the rotation will reset from 270 to 0 instead of 360 and a working URL is provided.