### PR TITLE
Fix link rendering in download dialogues

### DIFF
--- a/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
+++ b/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx
@@ -496,7 +496,7 @@ const DownloadDialogue = ({
     defaultLabel: string;
     type: DownloadOption;
   }) {
-    const renderings: Rendering[] = resource.getRenderings();
+    const renderings: Rendering[] = getSafeRenderings(resource.getRenderings());
 
     return (
       <>
@@ -539,10 +539,23 @@ const DownloadDialogue = ({
   //   return resource.getRenderings().length > 0;
   // }
 
+  function isSafeRenderingUri(uri) {
+    try {
+      const parsed = new URL(uri, window.location.href);
+      return ["http:", "https:"].includes(parsed.protocol);
+    } catch {
+      return false;
+    }
+  }
+
+  function getSafeRenderings(renderings: Rendering[]): Rendering[] {
+    return renderings.filter((r: Rendering) => isSafeRenderingUri(r.id));
+  }
+
   function hasRangeRenderings(): boolean {
     const canvas: Canvas = getSelectedCanvas();
     return (canvas.ranges ?? []).some(
-      (range: Range) => range.getRenderings().length > 0
+      (range: Range) => getSafeRenderings(range.getRenderings()).length > 0
     );
   }
 
@@ -566,9 +579,9 @@ const DownloadDialogue = ({
   function hasImageRenderings() {
     const canvas: Canvas = getSelectedCanvas();
     const images: Annotation[] = canvas.getImages();
-
     return images.some(
-      (image: Annotation) => image.getResource().getRenderings().length > 0
+      (image: Annotation) =>
+        getSafeRenderings(image.getResource().getRenderings()).length > 0
     );
   }
 
@@ -592,7 +605,7 @@ const DownloadDialogue = ({
 
   function hasCanvasRenderings() {
     const canvas: Canvas = getSelectedCanvas();
-    return canvas.getRenderings().length > 0;
+    return getSafeRenderings(canvas.getRenderings()).length > 0;
   }
 
   function CanvasRenderings() {
@@ -609,7 +622,8 @@ const DownloadDialogue = ({
 
   function hasManifestRenderings(): boolean {
     return (
-      sequence.getRenderings().length > 0 || manifest.getRenderings().length > 0
+      getSafeRenderings(sequence.getRenderings()).length > 0 ||
+      getSafeRenderings(manifest.getRenderings()).length > 0
     );
   }
 

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
@@ -124,6 +124,7 @@ export class DownloadDialogue extends Dialogue<
         if (renderingFormat) {
           format = renderingFormat.toString();
         }
+
         this.addEntireFileDownloadOption(
           rendering.id,
           <string>LanguageMap.getValue(rendering.getLabel()),

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
@@ -184,13 +184,16 @@ export class DownloadDialogue extends Dialogue<
       label += " (" + fileType + ")";
     }
 
-    this.$downloadOptions.append(
-      '<li><a href="' +
-        uri +
-        '" target="_blank" download tabindex="0">' +
-        label +
-        "</li>"
-    );
+    const $link = $("<a>", {
+      href: uri,
+      target: "_blank",
+      download: "",
+      tabindex: "0",
+      text: label,
+    });
+
+    const $li = $("<li>").append($link);
+    this.$downloadOptions.append($li);
   }
 
   resetDynamicDownloadOptions(): void {

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
@@ -91,6 +91,15 @@ export class DownloadDialogue extends Dialogue<
     this.updateTermsOfUseButton();
   }
 
+ isSafeRenderingUri(uri) {
+    try {
+      const parsed = new URL(uri, window.location.href);
+      return ["http:", "https:"].includes(parsed.protocol);
+    } catch {
+      return false;
+    }
+  }
+
   addEntireFileDownloadOptions(): void {
     if (
       this.isDownloadOptionAvailable(DownloadOption.ENTIRE_FILE_AS_ORIGINAL)
@@ -104,7 +113,9 @@ export class DownloadDialogue extends Dialogue<
 
       let renderingFound: boolean = false;
 
-      const renderings: Rendering[] = canvas.getRenderings();
+    const renderings: Rendering[] = canvas
+      .getRenderings()
+      .filter((r: Rendering) => this.isSafeRenderingUri(r.id));
 
       for (let i = 0; i < renderings.length; i++) {
         const rendering: Rendering = renderings[i];
@@ -130,7 +141,7 @@ export class DownloadDialogue extends Dialogue<
           const annotation: Annotation = annotations[i];
           const body: AnnotationBody[] = annotation.getBody();
 
-          if (body.length) {
+          if (body.length && this.isSafeRenderingUri(body[0].id)) {
             const format: MediaType | null = body[0].getFormat();
 
             if (format) {
@@ -192,7 +203,9 @@ export class DownloadDialogue extends Dialogue<
     defaultLabel: string,
     type: DownloadOption
   ): IRenderingOption[] {
-    const renderings: Rendering[] = resource.getRenderings();
+  const renderings: Rendering[] = resource
+    .getRenderings()
+    .filter((r: Rendering) => this.isSafeRenderingUri(r.id));
 
     const downloadOptions: any[] = [];
 

--- a/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
+++ b/src/content-handlers/iiif/modules/uv-dialogues-module/DownloadDialogue.ts
@@ -91,7 +91,7 @@ export class DownloadDialogue extends Dialogue<
     this.updateTermsOfUseButton();
   }
 
- isSafeRenderingUri(uri) {
+  isSafeRenderingUri(uri) {
     try {
       const parsed = new URL(uri, window.location.href);
       return ["http:", "https:"].includes(parsed.protocol);
@@ -113,9 +113,9 @@ export class DownloadDialogue extends Dialogue<
 
       let renderingFound: boolean = false;
 
-    const renderings: Rendering[] = canvas
-      .getRenderings()
-      .filter((r: Rendering) => this.isSafeRenderingUri(r.id));
+      const renderings: Rendering[] = canvas
+        .getRenderings()
+        .filter((r: Rendering) => this.isSafeRenderingUri(r.id));
 
       for (let i = 0; i < renderings.length; i++) {
         const rendering: Rendering = renderings[i];
@@ -207,9 +207,9 @@ export class DownloadDialogue extends Dialogue<
     defaultLabel: string,
     type: DownloadOption
   ): IRenderingOption[] {
-  const renderings: Rendering[] = resource
-    .getRenderings()
-    .filter((r: Rendering) => this.isSafeRenderingUri(r.id));
+    const renderings: Rendering[] = resource
+      .getRenderings()
+      .filter((r: Rendering) => this.isSafeRenderingUri(r.id));
 
     const downloadOptions: any[] = [];
 


### PR DESCRIPTION
This tightens up the rendering of links in the download dialogue for both the PDF and OSD extensions.

### PDF Download Dialogue
The link was being built with string concatenation. I've replaced this with attributes supplied to the JQuery element via an object. 

This manifest has a  rendering ID with Javascript that is now avoided: https://gist.githubusercontent.com/jamesmisson/15c81934ef12175441cab96ac53d0653/raw/3d67b52f1b92a2a0f7f9ffadd6648ee4d215c023/pdf-download-rendering.json

### OSD Download Dialogue
The `Rendering` component allowed Javascript to be supplied in the rendering ID. I've added a filter that checks that the ID begins with http/https, and used it in the relevant places. We should probably give some thought to what passes through this filter, but this implements the mechanism at least.

Download Option section headings are rendered conditionally via `has*Renderings` functions (e.g. `hasCanvasRenderings`, so I've used the new `getSafeRenderings` in all of these, as well as in the `Renderings` themselves.

This fix works with the manifest supplied: https://gist.githubusercontent.com/jamesmisson/1086007969f7f9947a729caf06b139d8/raw/e548676547355a248f85a912e6584fb7834b2281/poc3.json

