### PR TITLE
Update value as empty string for OSD Icon path prefixUrl 

### DIFF
--- a/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
+++ b/src/content-handlers/iiif/modules/uv-openseadragoncenterpanel-module/OpenSeadragonCenterPanel.ts
@@ -318,7 +318,7 @@ export class OpenSeadragonCenterPanel extends CenterPanel<
         this.config.options.autoHideControls,
         true
       ),
-      prefixUrl: undefined,
+      prefixUrl: "",
       gestureSettingsMouse: {
         clickToZoom: Bools.getBool(
           this.extension.data.config!.options.clickToZoomEnabled,


### PR DESCRIPTION
Fixes an issue where control icons in OSD Center panel were using a url prefix path of '/images/' on a base64 encoded transparent pixel causing a 404 error on control icon image tags. 
Described in this issue here https://github.com/UniversalViewer/universalviewer/issues/17893 
#17893 

OSD docs for prefixUrl here https://openseadragon.github.io/docs/openseadragon.js.html#:~:text=Finally%20the%0A%20%20*%20%20%20%20%20image,through%20this%20setting

Bug seamed to appear after OSD v6 upgrade where this value was changed from null to undefined triggering the default value to be used. https://github.com/UniversalViewer/universalviewer/commit/45d8b9cb6599afd05d68b89fa2edf02a8e80734d#diff-9a1d014d237071dac5bf1e798e67c9c2bcda2060d8be4ee978a87e0a68f9a954R283