### PR TITLE
Raise Node requirement to 22.15.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '20' ]
+        node: [ '22' ]
 
     name: Node ${{ matrix.node }} build
     steps:

--- a/.github/workflows/lint-and-prettify.yml
+++ b/.github/workflows/lint-and-prettify.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Checkout
         uses: actions/checkout@v7

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "webpack-dev-server": "5.2.6"
       },
       "engines": {
-        "node": ">=20",
+        "node": ">=22.15",
         "npm": ">=8.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.4.2",
   "description": "The Universal Viewer is a community-developed open source project on a mission to help you share your 📚📜📰📽️📻🗿 with the 🌎",
   "engines": {
-    "node": ">=20",
+    "node": ">=22.15",
     "npm": ">=8.1.1"
   },
   "files": [


### PR DESCRIPTION
Node 20 is no longer supported, and dependencies are starting to require Node 22 (see, e.g., #1830). This PR raises the minimum version to a known stable Node 22 version.